### PR TITLE
Refactor/전역 에러 처리 시스템 재구성

### DIFF
--- a/src/app/providers/AuthProvider.tsx
+++ b/src/app/providers/AuthProvider.tsx
@@ -2,7 +2,6 @@
 
 import {useEffect} from 'react';
 import {getSession, useUpdateUser} from '@/entities/auth';
-import {useUpdateGlobalError} from '@/entities/error';
 
 type Props = {
   children: React.ReactNode;
@@ -10,19 +9,10 @@ type Props = {
 
 export default function AuthProvider({children}: Props) {
   const updateUser = useUpdateUser();
-  const updateError = useUpdateGlobalError();
 
   useEffect(() => {
-    getSession()
-      .then(res => {
-        updateUser(res);
-      })
-      .catch(err => {
-        updateError(err);
-      });
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+    getSession().then(updateUser);
+  }, [updateUser]);
 
   return children;
 }

--- a/src/app/providers/GlobalErrorDetector.tsx
+++ b/src/app/providers/GlobalErrorDetector.tsx
@@ -23,14 +23,18 @@ export default function GlobalErrorDetector({children}: Props) {
         description: SERVER_ERROR_MESSAGE[globalError.errorCode],
       });
 
+      if (globalError.errorCode === 'TOKEN_EXPIRED') {
+        window.location.href = '/';
+      }
+
       return;
     }
 
     if (isClientError(globalError)) {
       toast.error({
-        title: "에러가 발생했어요.",
-        description: ERROR_MESSAGE[globalError.errorCode]
-      })
+        title: '에러가 발생했어요.',
+        description: ERROR_MESSAGE[globalError.errorCode],
+      });
 
       return;
     }

--- a/src/app/providers/ReactQueryProvider.tsx
+++ b/src/app/providers/ReactQueryProvider.tsx
@@ -1,16 +1,12 @@
 'use client';
 
-import {MutationCache, QueryCache, QueryClient, QueryClientProvider} from '@tanstack/react-query';
-import {useUpdateGlobalError} from '@/entities/error';
-import {RequestError, RequestGetError} from '@/shared/apis/request-error';
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
 
 type Props = {
   children: React.ReactNode;
 };
 
 const ReactQueryProvider = ({children}: Props) => {
-  const updateError = useUpdateGlobalError();
-
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: {
@@ -20,22 +16,8 @@ const ReactQueryProvider = ({children}: Props) => {
         gcTime: 1000 * 60 * 5,
 
         retry: 0,
-
-        // GET 요청이면서 errorHandlingType이 errorBoundary인 경우에만 에러를 던짐
-        throwOnError: (error: Error) => error instanceof RequestGetError && error.errorHandlingType === 'errorBoundary',
       },
     },
-    queryCache: new QueryCache({
-      onError(error) {
-        if (error instanceof RequestGetError && error.errorHandlingType === 'errorBoundary') return;
-        if (error instanceof RequestError) updateError(error);
-      },
-    }),
-    mutationCache: new MutationCache({
-      onError(error) {
-        if (error instanceof RequestError) updateError(error);
-      },
-    }),
   });
 
   return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;

--- a/src/entities/error/index.ts
+++ b/src/entities/error/index.ts
@@ -1,1 +1,1 @@
-export {useGlobalError, useUpdateGlobalError} from './store/errorStore';
+export {useGlobalError, useUpdateGlobalError, reportGlobalError} from './store/errorStore';

--- a/src/entities/error/store/errorStore.ts
+++ b/src/entities/error/store/errorStore.ts
@@ -17,3 +17,7 @@ const globalErrorStore = create<State & Action>(set => ({
 
 export const useGlobalError = () => globalErrorStore(state => state.error);
 export const useUpdateGlobalError = () => globalErrorStore(state => state.updateError);
+
+export const reportGlobalError = (error: State['error']) => {
+  globalErrorStore.setState({error});
+};

--- a/src/shared/apis/api-service.ts
+++ b/src/shared/apis/api-service.ts
@@ -127,7 +127,15 @@ async function request<T>(props: WithErrorHandling<RequestProps>): Promise<T> {
       response = await fetch(url, requestInit);
     } else {
       if (isBrowser()) {
-        window.location.href = '/login';
+        throw new RequestError({
+          status: 401,
+          endpoint: url,
+          method: requestInit.method,
+          requestBody: requestInit.body ? JSON.stringify(requestInit.body) : null,
+          errorCode: 'TOKEN_EXPIRED',
+          message: '로그인 세션이 만료되었습니다.',
+          name: 'TOKEN_EXPIRED',
+        });
       }
     }
   }

--- a/src/shared/apis/api-service.ts
+++ b/src/shared/apis/api-service.ts
@@ -183,13 +183,15 @@ export async function requestGet<T>({
   errorHandlingType,
   ...args
 }: WithErrorHandling<RequestMethodProps>): Promise<T> {
-  return request<T>({
-    ...args,
-    method: 'GET',
-    headers,
-    withResponse: true,
-    errorHandlingType,
-  });
+  return requestWithErrorHandling(() =>
+    request<T>({
+      ...args,
+      method: 'GET',
+      headers,
+      withResponse: true,
+      errorHandlingType,
+    }),
+  );
 }
 
 /**
@@ -202,12 +204,14 @@ export async function requestPost<T = void>({
   withResponse = false,
   ...args
 }: RequestMethodProps): Promise<T> {
-  return request<T>({
-    ...args,
-    method: 'POST',
-    headers,
-    withResponse,
-  });
+  return requestWithErrorHandling(() =>
+    request<T>({
+      ...args,
+      method: 'POST',
+      headers,
+      withResponse,
+    }),
+  );
 }
 
 /**
@@ -220,12 +224,14 @@ export async function requestPut<T = void>({
   withResponse = false,
   ...args
 }: RequestMethodProps): Promise<T> {
-  return request<T>({
-    ...args,
-    method: 'PUT',
-    headers,
-    withResponse,
-  });
+  return requestWithErrorHandling(() =>
+    request<T>({
+      ...args,
+      method: 'PUT',
+      headers,
+      withResponse,
+    }),
+  );
 }
 
 /**
@@ -238,12 +244,14 @@ export async function requestDelete<T = void>({
   withResponse = false,
   ...args
 }: RequestMethodProps): Promise<T> {
-  return request<T>({
-    ...args,
-    method: 'DELETE',
-    headers,
-    withResponse,
-  });
+  return requestWithErrorHandling(() =>
+    request<T>({
+      ...args,
+      method: 'DELETE',
+      headers,
+      withResponse,
+    }),
+  );
 }
 
 /**
@@ -256,10 +264,12 @@ export async function requestPatch<T = void>({
   withResponse = false,
   ...args
 }: RequestMethodProps): Promise<T> {
-  return request<T>({
-    ...args,
-    method: 'PATCH',
-    headers,
-    withResponse,
-  });
+  return requestWithErrorHandling(() =>
+    request<T>({
+      ...args,
+      method: 'PATCH',
+      headers,
+      withResponse,
+    }),
+  );
 }


### PR DESCRIPTION
## 📝 요약(Summary)

기존 프로젝트의 에러 처리 흐름은 다음과 같은 한계가 존재했는데요.

- 리액트 쿼리 기반 요청만 전역적인 에러 핸들링이 가능하고, 그 외의 요청은 개별 try-catch 가 필요했습니다.
- - 전역 에러 스토어로의 업데이트 책임이 ReactQueryProvider에만 집중되어 있어 흐름이 단절되어 있었습니다.
- 로그인 세션 만료 등의 특정 상황에서 사용자에게 명확한 피드백 없이 강제 리다이렉트가 발생했습니다.

이런 문제점들을 해결하기 위해 에러 처리 흐름을 다음과 같이 재설계했습니다.

### 주요 변경 사항

1. requestWithErrorHandling 래핑 함수 구현
- 모든 API 요청(requestGet, requestPost 등)을 감싸는 공통 에러 핸들링 래퍼 함수 구현
- 브라우저 환경에서만 zustand 스토어를 직접 조작할 수 있도록 isBrowser() 유틸 함수로 조건부 처리.
- GET 요청의 경우 'errorHandlingType'에 따라 throw 혹은 reportGlobalError 분기 처리.
- 기차 요청은 모두 전역 스토어에 상태 저장 후 에러 전파 차단.

2. ReactQueryProvider의 onError 콜백 제거
- 기존 queryCache/mutationCache의 전역 에러 핸들링 제거.
- React Query는 이제 순수한 쿼리 캐싱 레이어만 담당.
- 에러 처리는 API 요청 계층에서 전담하며 관심사 분리.

3. 401 Unauthrized 응답 흐름 개선
- 인증 만료 시 'RequestError'를 throw해 전역 에러 감지기로 전달.
- 'GlobalErrorDetector'에서 해당 에러 코드(TOKEN_EXPIRED)를 감지한 뒤 토스트 메세지 출력 및 메인 페이지로 리다이렉트.

4. AuthProvider의 getSession 요청 에러 처리 개선
- 기존 AuthProvider의 수동 catch 제거.
- 에러가 전역 흐름을 탈 수 있도록 위임해 일관된 UX 유지.

### 구조적 이점

위의 변경 사항으로 모든 에러 흐름이 하나의 시스템(requestWithErrorHandling => zustand store => GlobalErrorDetector)으로 통합됐습니다.

컴포넌트/페이지 별 리액트 쿼리를 통하지 않은 모든 API 요청에 대해 try-catch를 제거할 수 있어 코드 일관성과 유지보수성이 향상되었습니다.

리액트 쿼리에 의존하지 않고도 모든 비동기 요청이 통일된 방식으로 에러를 처리할 수 있습니다.

## 🛠️ PR 유형

- [X] 코드 리팩토링

## 💬 공유사항 to 리뷰어

`requestWithErrorHandling` 래퍼 함수 내부에서 전역 에러 스토어로 에러를 업데이트하는 로직을 보면,
```typescript
async function requestWithErrorHandling<T>(fn: () => Promise<T>): Promise<T | never> {
  try {
    return await fn();
  } catch (error) {
    if (!isBrowser()) {
      return Promise.reject(error);
    }

    if (error instanceof RequestGetError) {
      if (error.errorHandlingType === 'errorBoundary') throw error;
      else reportGlobalError(error);

      return Promise.reject(error);
    }

    if (error instanceof RequestError) {
      reportGlobalError(error);

      return Promise.reject(error);
    }

    throw error;
  }
}
```
이렇게 `reportGlobalError`를 호출하고 있는데요.
```typescript
const globalErrorStore = create<State & Action>(set => ({
  error: null,
  updateError: error => set({error}),
}));

export const useGlobalError = () => globalErrorStore(state => state.error);
export const useUpdateGlobalError = () => globalErrorStore(state => state.updateError);

export const reportGlobalError = (error: State['error']) => {
  globalErrorStore.setState({error});
};
```
어째서 기존의 `useUpdateGlobalError`를 두고 새로운 함수를 정의해 사용하는가? 에 대해 공유해보고자 합니다.

## zustand는 어떻게 동작할까?
zustand 소스 코드를 살펴보기에 앞서 당연히 우리는 리액트를 사용하니 `react.ts`를 확인해야 해요. 그런데 막상 열어보면 핵심 로직은 `vanilla.ts`에 담겨있어서 먼저 `vanilla.ts`를 확인해볼게요.

zustand의 `vaniila.ts`는 리액트에 의존하지 않은 순수한 상태 관리 로직이 담긴 핵심 모듈이라고 볼 수 있어요. 타입 정의부는 모두 무시하고 로직만 살펴볼게요.
```typescript
const createStoreImpl = createState => {
  let state;
  const listeners = new Set();

  const setState = (partial, replace) => {
    const nextState = typeof partial === 'function' ? partial(state) : partial;
    if (!Object.is(nextState, state)) {
      const previousState = state;
      state =
        (replace ?? (typeof nextState !== 'object' || nextState === null))
          ? nextState
          : Object.assign({}, state, nextState);
      listeners.forEach(listener => listener(state, previousState));
    }
  };

  const getState = () => state;

  const getInitialState = () => initialState;

  const subscribe = listener => {
    listeners.add(listener);
    // Unsubscribe
    return () => listeners.delete(listener);
  };

  const api = {setState, getState, getInitialState, subscribe};
  const initialState = (state = createState(setState, getState, api));
  return api;
};

export const createStore = createState => (createState ? createStoreImpl(createState) : createStoreImpl);
```
보면 노출되는 함수는 `createStore` 함수니 아래부터 따라 올라가면서 확인하면 좋을 것 같아요.

### createStore
```typescript
export const createStore = createState => (createState ? createStoreImpl(createState) : createStoreImpl);
```
사용자에게 노출되는 최종 함수인데요. 조건부 로직으로 두 가지 사용 패턴을 지원해요. 카운터 스토어를 만든다면 아래와 같을 거예요.
```typescript
// 상태 생성 함수를 직접 제공
const countStore = createStore((set) => ({
  count: 0,
  increment: () => set(state => ({ count: state.count + 1 })),
}))

// 인자 없이 호출한 뒤 반환된 함수에 상태 생성 함수 제공
const countStore = createStore()(set => ({
  /* 위와 동일 */
}))
```
`createState`가 제공되었다면 즉시 `createStoreImpl`을 호출해 스토어를 생성하고, 그렇지 않으면 `createStoreImpl` 함수 자체를 반환해 나중에 호출 가능하게 해요.

그럼 호출되는 `createStoreImpl` 함수를 살펴볼게요.
### createStoreImpl
1. **변수 선언부**
```typescript
let state;
const listeners = new Set();
```
가장 상단에 변수 선언이 되어있는데요. `state`는 현재 상태를 저장할 변수, `listeners`는 리스너 집합으로 Set 자료형으로 중복을 방지하고 있어요.

2. **setState**
```typescript
const setState = (partial, replace) => {
  const nextState = typeof partial === 'function' ? partial(state) : partial;
  if (!Object.is(nextState, state)) {
    const previousState = state;
    state =
      (replace ?? (typeof nextState !== 'object' || nextState === null))
        ? nextState
        : Object.assign({}, state, nextState);
    listeners.forEach(listener => listener(state, previousState));
  }
};
```
다음으로 `setState()` 함수로 zustand 스토어 내부 상태를 업데이트하는 **유일한 방법**이라고 보면 돼요. 입력의 형태는 다양할 수 있고 변경 사항이 있으면 구독자들에게 알리는 역할까지 담당하고 있어요.

먼저 `nextState`의 조건부에 대해 이해해볼게요. 만약 `partial`이 함수라면 `state`를 인자로 넘겨 실행해요. 하지만 `partial`이 값 자체라면 그 자체가 다음 상태가 돼요.

조금 어렵죠? 예시로 볼게요.
```typescript
setState({ count: 2 });
```
이 경우 `nextState`은 `{ count : 2 }`로 값 자체가 상태가 돼요.
```typescript
setState(state => ({ count: state.count + 1 }))
``` 
이 경우 `nextState`은 함수의 실행 결과가 돼요.

다음으로 상태 비교와 업데이트 여부 판단 부분인데요.
```typescript
if (!Object.is(nextState, state)) {
  const previousState = state;
  state =
    (replace ?? (typeof nextState !== 'object' || nextState === null))
      ? nextState as TState
      : Object.assign({}, state, nextState);

  listeners.forEach((listener) => listener(state, previousState));
}
```
`Object.is`를 통해 실제로 상태가 변경된 경우에만 실행되는 코드 블럭으로 값이 변경된 경우에만 아래 로직이 실행돼요.

`state`은 조건부를 통해 상태를 완전히 덮어쓸지, 혹은 병합할지 결정해요. 좀 난잡하게 생겼지만,
```typescript
state = condition ? 바꾸기 : 합치기;
```
`condition`이 `true`면 `state = nextState`로 완전히 갈아끼우고,
`condition`이 `false`면 `Object.assign`을 통해 병합한다고 생각하면 돼요.

마지막으로 리스너에게 상태 변경을 알리는데 여기서 listeners는 `subscribe()`로 등록된 함수들로 상태가 바뀔 때 구독 중인 컴포넌트 등에 알리는 부분입니다. 

3. **getState**
```typescript
const getState = () => state;
```
단순히 현재 상태를 반환해요.

4. **getInitialState**
```typescript
const getInitialState = () => initialState;
```
초기 상태를 반환해요.

5. **subscribe**
```typescript
const listeners: Set<Listener> = new Set();

const subscribe = listener => {
  listeners.add(listener);
  
  // Unsubscribe
  return () => listeners.delete(listener);
};
```
내부적으로 `listeners.add`로 상태가 변경될 때 실행될 함수를 등록하고, `listeners.delete`을 통해 해당 콜백을 해제해 구독을 종료해요.

그럼 위에서 살펴봤듯, 상태가 변경될 때 `setState` 내부에서 `listeners.forEach`로 모든 리스너들에게 알리게 되는 구조입니다.

6. **api, initialState**
```typescript
const api = { setState, getState, getInitialState, subscribe }
const initialState = (state = createState(setState, getState, api))
```
이 두 줄은 zustand의 `createStore()` 내부에서 스토어를 초기화하고 상태를 생성하는 부분입니다.

```typescript
return api
```
만들어진 API 객체를 반환해요.

자 코어 파일을 뜯어봤으니 이제 리액트에서 어떻게 동작하게 변환해주는지 `react.ts`를 확인해볼게요.

```typescript
const identity = arg => arg;
export function useStore(api, selector = identity) {
  const slice = React.useSyncExternalStore(
    api.subscribe,
    () => selector(api.getState()),
    () => selector(api.getInitialState()),
  );
  React.useDebugValue(slice);
  return slice;
}

const createImpl = createState => {
  const api = createStore(createState);

  const useBoundStore = selector => useStore(api, selector);

  Object.assign(useBoundStore, api);

  return useBoundStore;
};

export const create = createState => (createState ? createImpl(createState) : createImpl);
```
`vanilla.ts`를 보고 오니 비슷하죠? 우리에게 노출되는 최종 함수는 `create`이니 마찬가지로 따라 올라가면서 확인해볼게요.

### create
```typescript
export const create = (createState) => createState ? createImpl(createState) : createImpl
```
`create` 함수는 우리에게 노출되는 최종 함수로 인자로 상태 생성 함수를 직접 제공하거나, 혹은 인자 없이 호출한 뒤 반환된 함수에 상태 생성 함수를 제공하는 방식으로 사용이 가능합니다.

그럼 내부적으로 `createState`가 제공되었는지 확인한 뒤 제공되었다면 바로 `createImpl`을 호출하고 제공되지 않았다면 `createImpl` 함수 자체를 반환해 나중에 호출할 수 있게 됩니다.  근데 위에서 봤던 `createStore`랑 똑같죠? 바로 내부에서 호출하는 `createImpl` 함수를 살펴볼게요.

### createImpl
```typescript
const createImpl = (createState) => {
  const api = createStore(createState)

  const useBoundStore = (selector) => useStore(api, selector)

  Object.assign(useBoundStore, api)

  return useBoundStore
}
```
createImpl은 실제로 zustand 스토어를 생성하는 내부 구현 함수로 볼 수 있어요.
작동 순서는 다음과 같아요.
1. `createStore`를 호출해 스토어 API를 생성해요. 위에서 이미 다 보고 왔는데 핵심 API 로직이 담긴 객체였죠?
2. `useBoundStore` 함수를 정의해요. 이 함수는 선택자를 인자로 받아 `useStore` 훅을 호출해요.
3. `Object.assign(useBoundStore, api)`를 통해 `useBoundStore` 함수에 스토어 API의 모든 메서드를 복사해요.
   - 아주 흥미로운 부분인데, 함수이면서 객체로 동작하는 스토어를 만드는 핵심이라고 보면 돼요.
   - 이 줄 덕분에 `globalErrorStore.setState()`와 같은 방식으로 직접 스토어 API에 접근할 수 있는데, 지금은 아하?로 넘어가고 이후에 다시 보면 더 좋을 거 같아요.

이런 흐름을 통해 함수이면서 동시에 객체인 스토어를 반환하게 돼요. 그럼 `useStore`를 확인해볼게요.

### useStore
```typescript
const identity = arg => arg

export function useStore(api, selector = identity) {
  const slice = React.useSyncExternalStore(
    api.subscribe,
    () => selector(api.getState()),
    () => selector(api.getInitialState()),
  );
  return slice;
}
```
useStore는 zustand 스토어에서 리액트 컴포넌트가 어떤 상태를 구독할지 지정하고, 상태가 바뀔 때 해당 컴포넌트만 정확하게 리렌더링될 수 있게 추적하는 함수라고 볼 수 있어요.

인자로 두 가지를 받을 수 있는데요.
- **api**: zustand 스토어 API
- **selector**: 스토어의 전체 상태에서 필요한 부분만 선택하는 함수로 기본값은 전체 상태를 반환하는 `identity` 함수입니다.

### useSyncExternalStore
useStore 내부에선 리액트의 `useSyncExternalStore` 훅을 사용해요. 이 부분 때문에 함수 레벨에서 사용이 불가능해요. 훅의 규칙 때문이죠?

여기서 `useSyncExternalStore`는 리액트 18에서 도입된 훅으로 리액트 외부에서 상태가 바뀌는걸 감지하고 리렌더링을 트리거해줘요.

시그니처는 아래와 같아요.
```typescript
const value = useSyncExternalStore(
  subscribe: (onStoreChange) => () => void,
  getSnapshot: () => any,
  getServerSnapshot: () => any  // SSR 용
);
```
- **subscribe**은 상태가 바뀌면 알려주는 구독 함수.
- **getSnapshot**은 현재 상태를 가져오는 함수.
- **getServerSnapshot**은 SSR에 사용해요.

그럼 zustand는 여기에 어떻게 대응하고 있는지 확인해볼게요.
```typescript
React.useSyncExternalStore(
  api.subscribe,
  () => selector(api.getState()),
  () => selector(api.getInitialState()),
);
```
1. **subscribe에 api.subscribe을 전달하고 있어요.**
```typescript
api.subribe = (listener) => {
  listeners.add(listener);
  return () => listeners.delete(listener);
};
```
위의 코어 파일에서 확인했었죠?

그럼 리액트는 `useSyncExternalStore` 내부에서 `subscribe(listener)`를 실행해요. 여기서 listener는 리액트가 내부적으로 관리하는 **리렌더 트리거 콜백 함수**입니다.

어라! 즉, zustand 스토어의 값이 바뀌면? => `listeners.forEach(리렌더 => 리렌더())` 이렇게 실행된다는거죠?

아하, 그럼 이 부분은 zustand가 리액트로 **이벤트를 보내는 경로**라고 봐야겠네요.

2. **getSnapshot에 () => selector(api.getState());를 전달하고 있어요.**
```typescript
() => selector(api.getState())
```
이건 리렌더링 직전에 실행되는 상태 읽기 함수인데요. 그럼 상태가 바뀌었을 때 리액트는 `getSnapshot()`을 실행해요.

이 함수는 `api.getState()`를 호출하니 현재 zustand 스토어의 상태를 반환하겠죠? 그럼 `selector`로 가공해서 원하는 값만 가져와요. (state.count, state.error 등)

아하, 그럼 이 부분은 리액트에서 zustand로 **상태를 읽는 경로**라고 봐야겠네요.

3. getServerSnapshot?

이건 SSR 환경일 때 사용된다고 해요. 그냥 `getInitialState()`로 초기 상태를 가져온다고 생각하면 돼요.

자 여기까진 이해했는데, 그럼 이걸 왜 내부에서 호출하고 있을까요?
```typescript
무언가가담긴객체.value = 123;
```
리액트는 기본적으로 외부에서 직접 수정된 값에 반응하지 않아요. 위의 경우와 같이 객체의 value 값을 바꿔도 리렌더링이 발생하지 않아요.

그런데 zustand는 결국 리액트 외부에서 동작하는 전역 상태 관리 라이브러리죠? 위에서 코어 파일 확인했을 때, 순수하게 그냥 자바스크립트 로직이 담겨있었으니까요.

그래서 zustand는 리액트에게 상태가 바뀌었다고 알리는 메커니즘이 필요해지는데 그게 바로 `useSyncExternalStore`인 거예요.

### createImpl
```typescript
const createImpl = (createState) => {
  const api = createStore(createState)

  const useBoundStore = (selector) => useStore(api, selector)

  Object.assign(useBoundStore, api)

  return useBoundStore
}
```
자 다시 돌아와서 이제 `useBoundStore`는 이제 `useStore`를 통해 반환된 함수라는 것을 알았어요. 근데 스토어는 객체이면서 함수였죠?

자 JS에서 함수는 객체인데요.
```javascript
function 무언가() {}
```
이 함수는 아래와 같이 바꿀 수 있어요.
```javascript
const 무언가 = new Function(); // Function 인스턴스 (객체라는 말!!)
```
그럼 모든 함수는 객체니까 속성을 자유롭게 추가할 수 있어요.

자 그럼 이 `Object.assign`의 동작을 예시로 볼게요.
```javascript
function 나는함수(selector) {
  return selector(this.state);
}

const 나는객체 = {
  state: { count: 5 },
  getState() {
    return this.state;
  },
};

Object.assign(나는함수, 나는객체);

console.log(나는함수.getState()); // { count: 5 }
console.log(나는함수(s => s.count)); // 5
```
자 이렇게 나는함수지만, `getState`와 `state` 등의 속성도 가질 수 있는 거예요. 약간 하이브리드 차 같죠?

그러니까 결국 `useStore`로 반환된 함수에 api 객체를 합쳐서 최종적으로 만들어진 `useBoundStore`를 사용자에게 제공하게 돼요.

## 결론
정말 힘겹게 도착했는데요. 그렇다면 기존에 존재하던 `useUpdateGlobalError` 대신 `reportGlobalError` 함수를 새로 만든 이유는 무엇일까요?

`useUpdateGlobalError`는 내부적으로 `useStore` 훅을 호출하기 때문에, 리액트 훅의 규칙에 따라 반드시 컴포넌트 혹은 커스텀 훅 내부에서만 사용할 수 있어요. 하지만 `requestWithErrorHandling` 함수는 함수 레벨의 비동기 로직에서 동작하므로, 훅 호출이 불가능한 위치에 있습니다.

이에 반해 `reportGlobalError`는 zustand의 스토어 객체에 직접 접근해 `.setState()`를 호출하는 방식으로 구현되어 있어요. 이 방식은 훅이 아닌 **순수 함수 기반의 상태 변경 메서드**를 사용하는 것이기 때문에 리액트 훅의 규칙에 위배되지 않고, 컴포넌트 외부에서도 안전하게 호출할 수 있게 돼요.

zustand 내부 구현을 보면, 스토어 객체는 `createStore`를 통해 생성된 **싱글톤 객체**이며, 그 안의 `setState()`는 단순한 함수로 구성되어 있어 렌더링 컨텍스트나 리액트 훅 시스템과 무관하게 동작해요. 이러한 특성 덕분에 `reportGlobalError()`는 함수 레벨에서도 안전하고 일관되게 상태를 업데이트할 수 있어 개선하게 되었어요.
