### PR TITLE
Feat/검색 결과가 없음을 표시하는 UI 컴포넌트 구현

### DIFF
--- a/src/entities/reviews/index.ts
+++ b/src/entities/reviews/index.ts
@@ -6,3 +6,4 @@ export {default as ReviewArticleLoading} from './ui/ReviewArticleLoading';
 export {default as useCategoryReviews} from './model/useCategoryReviews';
 export {default as useKeywordReviews} from './model/useKeywordReviews';
 export {default as ReviewsLoading} from './ui/ReviewsLoading';
+export {default as NoSearchResults} from './ui/NoSearchResults';

--- a/src/entities/reviews/ui/NoSearchResults.tsx
+++ b/src/entities/reviews/ui/NoSearchResults.tsx
@@ -1,0 +1,18 @@
+type Props = {
+  title: string;
+  description: string;
+  description2?: string;
+};
+
+export default function NoSearchResults({title, description, description2}: Props) {
+  return (
+    <section className="flex flex-col items-center mt-[80px] md:mt-[130px]">
+      <h2 className="text-lg md:text-2xl font-bold mb-4">{title}</h2>
+      <p className="text-gray-600 text-center">
+        <span>{description}</span>
+        <br className="md:hidden" />
+        <span>{description2}</span>
+      </p>
+    </section>
+  );
+}

--- a/src/entities/reviews/ui/NoSearchResults.tsx
+++ b/src/entities/reviews/ui/NoSearchResults.tsx
@@ -10,8 +10,12 @@ export default function NoSearchResults({title, description, description2}: Prop
       <h2 className="text-lg md:text-2xl font-bold mb-4">{title}</h2>
       <p className="text-gray-600 text-center">
         <span>{description}</span>
-        <br className="md:hidden" />
-        <span>{description2}</span>
+        {description2 && (
+          <>
+            <br className="md:hidden" />
+            <span>{description2}</span>
+          </>
+        )}
       </p>
     </section>
   );

--- a/src/features/reviews/category/ui/ReviewWithScroll.tsx
+++ b/src/features/reviews/category/ui/ReviewWithScroll.tsx
@@ -1,6 +1,6 @@
 import {useCallback} from 'react';
 import {SortKey} from '@/features/reviews/sorting';
-import {ReviewArticle, ReviewArticleLoading, useCategoryReviews} from '@/entities/reviews';
+import {NoSearchResults, ReviewArticle, ReviewArticleLoading, useCategoryReviews} from '@/entities/reviews';
 import {LucideIcon} from '@/shared/ui/icons';
 
 type Props = {
@@ -27,6 +27,15 @@ export default function ReviewsWithScroll({selectedCategory, sort}: Props) {
     },
     [hasNextPage, fetchNextPage],
   );
+
+  if (data.pages[0].results.length === 0) {
+    return (
+      <NoSearchResults
+        title="아직 해당 카테고리에 리뷰가 등록되지 않았어요."
+        description="다른 카테고리를 클릭해 리뷰를 확인해보세요!"
+      />
+    );
+  }
 
   return (
     <>

--- a/src/features/reviews/keyword/ui/ReviewWithPagination.tsx
+++ b/src/features/reviews/keyword/ui/ReviewWithPagination.tsx
@@ -3,7 +3,7 @@
 import {useParams, useSearchParams} from 'next/navigation';
 import Pagination from '@/widgets/pagination';
 import {SortKey} from '@/features/reviews/sorting';
-import {ReviewArticle, useKeywordReviews} from '@/entities/reviews';
+import {NoSearchResults, ReviewArticle, useKeywordReviews} from '@/entities/reviews';
 
 type Props = {
   sort: SortKey;
@@ -15,6 +15,16 @@ export default function ReviewWithPagination({sort}: Props) {
 
   const currentPage = Number(searchParams.get('page')) || 1;
   const {results, total_pages} = useKeywordReviews(keyword, currentPage, sort);
+
+  if (results.length === 0) {
+    return (
+      <NoSearchResults
+        title={`${decodeURIComponent(keyword)}에 대한 검색 결과가 없어요.`}
+        description="검색어의 철자가 정확한지 확인해주세요."
+        description2="또는 검색어를 변경해 다시 검색할 수 있어요."
+      />
+    );
+  }
 
   return (
     <ul className="flex flex-col mb-6">


### PR DESCRIPTION
## 📝 요약(Summary)

- 키워드 검색, 카테고리 검색 시 검색 결과가 없음을 표시하는 UI 컴포넌트 구현.
- title, description을 인자로 받아 표시.
- 모바일 환경에서 description과 description2 사이에 줄바꿈 표시.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가

## 📸스크린샷

### 카테고리 기반 검색
![no-search-result-category](https://github.com/user-attachments/assets/97e9164f-28a8-4795-918a-e94141f6bdfc)

### 키워드 기반 검색
![no-search-result-keyword](https://github.com/user-attachments/assets/47f35dbf-565e-40ae-a7a3-a69231c98737)