### PR TITLE
(공통) - Refactor/페이지네이션 Link 태그의 scroll 속성을 인자로 받도록 설정

### DIFF
--- a/src/app/layouts/index.tsx
+++ b/src/app/layouts/index.tsx
@@ -21,7 +21,7 @@ export function RootLayout({
 }>) {
   return (
     <html lang="en" className="w-full h-full overflow-y-auto">
-      <body className={`${pretandard.className} antialiased flex flex-col w-full h-full overflow-x-hidden`}>
+      <body className={`${pretandard.className} antialiased flex flex-col w-full overflow-x-hidden`}>
         <Providers>
           <Header />
           <main className="grow w-full mx-auto">{children}</main>

--- a/src/features/review/comments/ui/CommentsList.tsx
+++ b/src/features/review/comments/ui/CommentsList.tsx
@@ -23,6 +23,7 @@ export default function CommentsList({comments, currentPage, totalPages}: Props)
         totalPages={totalPages}
         generateUrl={page => `?page=${page}`}
         className="my-5"
+        scrollToTop={false}
       />
     </>
   );

--- a/src/features/reviews/my/ui/ReviewList.tsx
+++ b/src/features/reviews/my/ui/ReviewList.tsx
@@ -23,6 +23,7 @@ export default function ReviewList({reviews, currentPage, totalPages, tabs}: Pro
         totalPages={totalPages}
         generateUrl={(page: number) => `?tabs=${tabs}&page=${page}`}
         className="bg-white px-1.5 md:px-5 py-1.5 rounded-md shadow-md mb-4"
+        scrollToTop={false}
       />
     </>
   );

--- a/src/views/mypage/ui/ReviewTabs.tsx
+++ b/src/views/mypage/ui/ReviewTabs.tsx
@@ -19,7 +19,7 @@ export default function ReviewTabs() {
   const tabsRef = useRef<HTMLDivElement>(null);
 
   const handleTabChange = (value: string) => {
-    router.push('/mypage?tabs=' + value);
+    router.push('/mypage?tabs=' + value, {scroll: false});
   };
 
   useEffect(() => {

--- a/src/widgets/pagination/ui/Pagination.tsx
+++ b/src/widgets/pagination/ui/Pagination.tsx
@@ -15,14 +15,21 @@ type Props = {
   totalPages: number;
   generateUrl: (page: number) => string;
   className?: string;
+  scrollToTop: boolean;
 };
 
-export default function Pagination({totalPages, currentPage, generateUrl, className}: Props) {
+export default function Pagination({totalPages, currentPage, generateUrl, className, scrollToTop = true}: Props) {
   function renderPageNumbers() {
     if (totalPages === 1) {
       return (
         <PaginationItem key={1}>
-          <PaginationLink href={generateUrl(1)} isActive={true}>
+          <PaginationLink
+            href={generateUrl(1)}
+            className="pointer-events-none"
+            isActive={true}
+            aria-disabled={true}
+            scroll={scrollToTop}
+          >
             1
           </PaginationLink>
         </PaginationItem>
@@ -41,7 +48,12 @@ export default function Pagination({totalPages, currentPage, generateUrl, classN
     if (currentPage > 2 && startPage > 1) {
       items.push(
         <PaginationItem key="first">
-          <PaginationLink href={generateUrl(1)} isActive={currentPage === 1}>
+          <PaginationLink
+            href={generateUrl(1)}
+            isActive={currentPage === 1}
+            aria-disabled={currentPage === 1}
+            scroll={scrollToTop}
+          >
             1
           </PaginationLink>
         </PaginationItem>,
@@ -61,10 +73,11 @@ export default function Pagination({totalPages, currentPage, generateUrl, classN
         <PaginationItem key={i}>
           <PaginationLink
             href={generateUrl(i)}
+            className={`${currentPage === i && 'pointer-events-none'}`}
             isActive={currentPage === i}
             aria-disabled={currentPage === i}
             tabIndex={currentPage === i ? -1 : 0}
-            className={`${currentPage === i && 'pointer-events-none'}`}
+            scroll={scrollToTop}
           >
             {i}
           </PaginationLink>
@@ -83,7 +96,12 @@ export default function Pagination({totalPages, currentPage, generateUrl, classN
     if (currentPage < totalPages - 1 && endPage < totalPages) {
       items.push(
         <PaginationItem key="last">
-          <PaginationLink href={generateUrl(totalPages)} isActive={currentPage === totalPages}>
+          <PaginationLink
+            href={generateUrl(totalPages)}
+            isActive={currentPage === totalPages}
+            aria-disabled={currentPage === totalPages}
+            scroll={scrollToTop}
+          >
             {totalPages}
           </PaginationLink>
         </PaginationItem>,
@@ -102,6 +120,7 @@ export default function Pagination({totalPages, currentPage, generateUrl, classN
             aria-disabled={currentPage === 1}
             tabIndex={currentPage === 1 ? -1 : 0}
             className={`${currentPage === 1 && 'pointer-events-none opacity-50'}`}
+            scroll={scrollToTop}
           />
         </PaginationItem>
         {renderPageNumbers()}
@@ -111,6 +130,7 @@ export default function Pagination({totalPages, currentPage, generateUrl, classN
             aria-disabled={currentPage === totalPages}
             tabIndex={currentPage === totalPages ? -1 : 0}
             className={`${currentPage === totalPages && 'pointer-events-none opacity-50'}`}
+            scroll={scrollToTop}
           />
         </PaginationItem>
       </PaginationContent>

--- a/src/widgets/pagination/ui/Pagination.tsx
+++ b/src/widgets/pagination/ui/Pagination.tsx
@@ -15,7 +15,7 @@ type Props = {
   totalPages: number;
   generateUrl: (page: number) => string;
   className?: string;
-  scrollToTop: boolean;
+  scrollToTop?: boolean;
 };
 
 export default function Pagination({totalPages, currentPage, generateUrl, className, scrollToTop = true}: Props) {


### PR DESCRIPTION
## 📝 요약(Summary)

### 배경
- 현재 페이지네이션은 url 기반으로 Link 태그를 클릭해 href 속성에 명시된 url로 이동합니다.
- Link 태그의 scroll 속성의 기본값은 true로, Link 태그를 통해 페이지가 이동되면 스크롤이 화면 최상단으로 이동하는 구조입니다.

### 문제
- 게시글 상세보기 페이지의 경우, 사용자가 댓글 조회를 위해 페이지네이션의 요소를 클릭해 페이지를 이동하는 구조입니다. 이 때, 페이지가 최상단으로 이동해 사용자는 변경된 페이지의 댓글을 보기 위해 게시글 영역만큼 다시 내려오는 문제가 발생합니다.
- 마이페이지의 경우, 페이지 컴포넌트가 fixed 속성으로 스크롤 주체가 뷰포트 기준으로 설정되어있습니다. 페이지네이션을 통해 페이지를 이동할 때, 스크롤 주체가 다른 상태에서 스크롤을 최상단으로 이동하려는 동작으로 인해 콘솔에 경고 메세지가 누적되는 문제가 발생했습니다.

### 해결
- 페이지네이션 컴포넌트의 인자로 scrollToTop을 받아 Link 태그의 scroll 속성으로 전달하도록 개선했습니다.
- 별도로 설정하지 않은 경우 기본값 true로 동작하도록 디폴트 파라미터를 설정했습니다.

## 🛠️ PR 유형

- [X] 버그 수정