### PR TITLE
(게시글 수정 페이지) - Feat/게시글 수정 페이지 구현

### DIFF
--- a/app/api/reviews/[reviewId]/route.ts
+++ b/app/api/reviews/[reviewId]/route.ts
@@ -1,4 +1,4 @@
-import {readFileSync} from 'fs';
+import {readFileSync, writeFileSync} from 'fs';
 import {NextRequest, NextResponse} from 'next/server';
 import path from 'path';
 
@@ -11,6 +11,46 @@ export async function GET(_: NextRequest, {params}: {params: Promise<{reviewId: 
     const fileData = readFileSync(filePath, 'utf-8');
 
     return NextResponse.json(JSON.parse(fileData));
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return NextResponse.json(
+        {
+          errorCode: 'REVIEW_NOT_FOOUND',
+          meesage: '리뷰를 찾을 수 없습니다.',
+        },
+        {
+          status: 404,
+        },
+      );
+    }
+
+    return NextResponse.json(
+      {
+        errorCode: 'INTERNAL_SERVER_ERROR',
+        message: '서버 오류가 발생했습니다.',
+      },
+      {
+        status: 500,
+      },
+    );
+  }
+}
+
+export async function PATCH(req: NextRequest, {params}: {params: Promise<{reviewId: string}>}) {
+  const {reviewId} = await params;
+  const filePath = path.join(process.cwd(), 'public/data', `review_detail_${reviewId}.json`);
+
+  try {
+    const fileData = readFileSync(filePath, 'utf-8');
+    const reviewData = JSON.parse(fileData);
+
+    const updatedData = await req.json();
+
+    const newReviewData = Object.assign(reviewData, updatedData);
+
+    writeFileSync(filePath, JSON.stringify(newReviewData));
+
+    return NextResponse.json({message: '리뷰가 성공적으로 수정되었습니다.'});
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
       return NextResponse.json(

--- a/app/api/reviews/[reviewId]/route.ts
+++ b/app/api/reviews/[reviewId]/route.ts
@@ -1,4 +1,6 @@
 import {readFileSync, writeFileSync} from 'fs';
+import {revalidateTag} from 'next/cache';
+import {cookies} from 'next/headers';
 import {NextRequest, NextResponse} from 'next/server';
 import path from 'path';
 
@@ -49,6 +51,7 @@ export async function PATCH(req: NextRequest, {params}: {params: Promise<{review
     const newReviewData = Object.assign(reviewData, updatedData);
 
     writeFileSync(filePath, JSON.stringify(newReviewData));
+    revalidateTag(`review-${reviewId}`);
 
     return NextResponse.json({message: '리뷰가 성공적으로 수정되었습니다.'});
   } catch (error) {
@@ -75,3 +78,62 @@ export async function PATCH(req: NextRequest, {params}: {params: Promise<{review
     );
   }
 }
+
+// TODO: 백엔드 API 구현 완료 후 주석 해제
+// export async function PATCH(req: NextRequest, {params}: {params: Promise<{reviewId: string}>}) {
+//   const {reviewId} = await params;
+
+//   if (!reviewId) {
+//     return NextResponse.json(
+//       {
+//         errorCode: 'REVIEW_ID_MISSING',
+//         message: '리뷰 ID가 제공되지 않았습니다.',
+//       },
+//       {
+//         status: 400,
+//       },
+//     );
+//   }
+
+//   const cookieStore = await cookies();
+//   const accessToken = cookieStore.get('accessToken');
+
+//   if (!accessToken) {
+//     return NextResponse.json(
+//       {
+//         errorCode: 'UNAUTHORIZED',
+//         message: '로그인이 필요합니다.',
+//       },
+//       {
+//         status: 401,
+//       },
+//     );
+//   }
+
+//   const reviewData = await req.json();
+
+//   const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/reviews/${reviewId}`, {
+//     method: 'PATCH',
+//     headers: {
+//       'Content-Type': 'application/json',
+//       Cookie: `accessToken=${accessToken.value}`,
+//     },
+//     body: JSON.stringify(reviewData),
+//   });
+
+//   if (!res.ok) {
+//     const errorData = await res.json();
+//     return NextResponse.json(
+//       {
+//         errorCode: errorData.errorCode || 'INTERNAL_SERVER_ERROR',
+//         message: errorData.message || '서버 오류가 발생했습니다.',
+//       },
+//       {
+//         status: res.status,
+//       },
+//     );
+//   }
+
+//   revalidateTag(`review-${reviewId}`);
+//   return NextResponse.json({status: 201});
+// }

--- a/app/reviews/[reviewId]/edit/page.ts
+++ b/app/reviews/[reviewId]/edit/page.ts
@@ -1,0 +1,1 @@
+export {EditReviewPage as default} from '@/views/review/edit';

--- a/src/entities/review/apis/api-service.ts
+++ b/src/entities/review/apis/api-service.ts
@@ -8,7 +8,7 @@ import {
   ReviewPayload,
   UploadImageProps,
 } from '../model/type';
-import {requestGet, requestPost} from '@/shared/apis';
+import {requestGet, requestPatch, requestPost} from '@/shared/apis';
 import {createClientError} from '@/shared/lib/utils/client-error';
 import {TErrorInfo} from '@/shared/apis/request-type';
 import {RequestGetError} from '@/shared/apis/request-error';
@@ -19,6 +19,14 @@ export async function postReview(data: ReviewPayload) {
     endpoint: '/review',
     body: data,
     withResponse: false,
+  });
+}
+
+export async function patchReview(data: ReviewPayload, reviewId: number) {
+  await requestPatch({
+    baseUrl: process.env.NEXT_PUBLIC_CLIENT_URL,
+    endpoint: `/api/reviews/${reviewId}`,
+    body: data,
   });
 }
 

--- a/src/entities/review/index.ts
+++ b/src/entities/review/index.ts
@@ -8,3 +8,4 @@ export {default as useGetReviewBookmarks} from './model/useGetReviewBookmarks';
 export {default as useToggleBookmark} from './model/useToggleBookmark';
 export {default as useGetReviewComments} from './model/useGetReviewComments';
 export {default as usePostReviewComment} from './model/usePostReviewComment';
+export {default as usePatchReview} from './model/usePatchReview';

--- a/src/entities/review/model/usePatchReview.ts
+++ b/src/entities/review/model/usePatchReview.ts
@@ -17,7 +17,7 @@ export default function usePatchReview() {
 
   const {mutate, ...rest} = useMutation({
     mutationFn: ({data, reviewId}: MutationVariables) => patchReview(data, reviewId),
-    onSuccess: (_data, {category}) => {
+    onSuccess: (_data, {category, reviewId}) => {
       toast.success({
         title: '리뷰를 성공적으로 수정했어요.',
       });
@@ -26,7 +26,7 @@ export default function usePatchReview() {
       // queryClient.invalidateQueries(reviewQueryKeys.search(category, 'recent'));
       // queryClient.invalidateQueries(reviewQueryKeys.search('all', 'recent'));
 
-      router.push('/search');
+      router.push(`/reviews/${reviewId}`);
     },
   });
 

--- a/src/entities/review/model/usePatchReview.ts
+++ b/src/entities/review/model/usePatchReview.ts
@@ -1,0 +1,37 @@
+'use client';
+
+import {useRouter} from 'next/navigation';
+import {useMutation, useQueryClient} from '@tanstack/react-query';
+import {patchReview} from '../apis/api-service';
+import {ReviewPayload} from './type';
+import toast from '@/shared/lib/utils/toastService';
+
+type MutationVariables = {
+  data: ReviewPayload;
+  reviewId: number;
+};
+
+export default function usePatchReview() {
+  const queryClient = useQueryClient();
+  const router = useRouter();
+
+  const {mutate, ...rest} = useMutation({
+    mutationFn: ({data, reviewId}: MutationVariables) => patchReview(data, reviewId),
+    onSuccess: (_data, {category}) => {
+      toast.success({
+        title: '리뷰를 성공적으로 수정했어요.',
+      });
+
+      // TODO: reviewQueryKeys => reviewsQueryKeys로 변경 후 주석 해제
+      // queryClient.invalidateQueries(reviewQueryKeys.search(category, 'recent'));
+      // queryClient.invalidateQueries(reviewQueryKeys.search('all', 'recent'));
+
+      router.push('/search');
+    },
+  });
+
+  return {
+    patchReview: mutate,
+    ...rest,
+  };
+}

--- a/src/views/review/edit/index.ts
+++ b/src/views/review/edit/index.ts
@@ -1,0 +1,1 @@
+export {default as EditReviewPage} from './ui/EditReviewPage';

--- a/src/views/review/edit/ui/EditReview.tsx
+++ b/src/views/review/edit/ui/EditReview.tsx
@@ -1,0 +1,16 @@
+import {getReviewDetail} from '@/entities/review';
+
+type Props = {
+  reviewId: number;
+  sessionUserEmail: string;
+};
+
+export default async function EditReview({reviewId, sessionUserEmail}: Props) {
+  const data = await getReviewDetail(reviewId);
+
+  if (data.author !== sessionUserEmail) {
+    throw new Error('작성자만 리뷰를 수정할 수 있습니다.');
+  }
+
+  return <>{/* TODO: EditReviewClient 컴포넌트 구현 후 onSave 콜백을 Editor 컴포넌트로 주입 */}</>;
+}

--- a/src/views/review/edit/ui/EditReview.tsx
+++ b/src/views/review/edit/ui/EditReview.tsx
@@ -1,4 +1,5 @@
 import {getReviewDetail} from '@/entities/review';
+import EditReviewClient from './EditReviewClient';
 
 type Props = {
   reviewId: number;
@@ -12,5 +13,5 @@ export default async function EditReview({reviewId, sessionUserEmail}: Props) {
     throw new Error('작성자만 리뷰를 수정할 수 있습니다.');
   }
 
-  return <>{/* TODO: EditReviewClient 컴포넌트 구현 후 onSave 콜백을 Editor 컴포넌트로 주입 */}</>;
+  return <EditReviewClient data={data} reviewId={reviewId} />;
 }

--- a/src/views/review/edit/ui/EditReviewClient.tsx
+++ b/src/views/review/edit/ui/EditReviewClient.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import {ReviewDetail, ReviewPayload, usePatchReview} from '@/entities/review';
+import {Editor} from '@/features/review/editor';
+
+type Props = {
+  data: ReviewDetail;
+  reviewId: number;
+};
+
+export default function EditReviewClient({data, reviewId}: Props) {
+  const {patchReview, isPending} = usePatchReview();
+
+  const handlePatchReview = (data: ReviewPayload) => {
+    patchReview({data, reviewId});
+  };
+
+  return (
+    <Editor
+      title={data.title}
+      category={data.category}
+      content={data.content}
+      onSave={handlePatchReview}
+      isPending={isPending}
+    />
+  );
+}

--- a/src/views/review/edit/ui/EditReviewPage.tsx
+++ b/src/views/review/edit/ui/EditReviewPage.tsx
@@ -1,0 +1,3 @@
+export default function EditReviewPage() {
+  return <section>리뷰 수정 페이지</section>;
+}

--- a/src/views/review/edit/ui/EditReviewPage.tsx
+++ b/src/views/review/edit/ui/EditReviewPage.tsx
@@ -1,3 +1,27 @@
-export default function EditReviewPage() {
-  return <section>리뷰 수정 페이지</section>;
+import {Suspense} from 'react';
+import {cookies} from 'next/headers';
+import {LoadingSpinner} from '@/shared/ui/components';
+
+type Props = {
+  params: Promise<{reviewId: string}>;
+};
+
+export default async function ReviewEditPage({params}: Props) {
+  const {reviewId} = await params;
+  const parsedReviewId = Number(reviewId);
+
+  const cookieStore = await cookies();
+  const sessionUserEmail = cookieStore.get('userEmail');
+
+  if (!sessionUserEmail) {
+    throw new Error('로그인 세션이 만료되었습니다. 다시 로그인해주세요.');
+  }
+
+  return (
+    <section className="fixed inset-0 bg-white">
+      <Suspense fallback={<LoadingSpinner text="리뷰 정보를 불러오고 있어요." />}>
+        {/* TODO: 에디터 컴포넌트를 사용한 리뷰 수정 기능 구현 */}
+      </Suspense>
+    </section>
+  );
 }

--- a/src/views/review/edit/ui/EditReviewPage.tsx
+++ b/src/views/review/edit/ui/EditReviewPage.tsx
@@ -1,5 +1,6 @@
 import {Suspense} from 'react';
 import {cookies} from 'next/headers';
+import EditReview from './EditReview';
 import {LoadingSpinner} from '@/shared/ui/components';
 
 type Props = {
@@ -20,7 +21,7 @@ export default async function ReviewEditPage({params}: Props) {
   return (
     <section className="fixed inset-0 bg-white">
       <Suspense fallback={<LoadingSpinner text="리뷰 정보를 불러오고 있어요." />}>
-        {/* TODO: 에디터 컴포넌트를 사용한 리뷰 수정 기능 구현 */}
+        <EditReview reviewId={parsedReviewId} sessionUserEmail={sessionUserEmail.value} />
       </Suspense>
     </section>
   );


### PR DESCRIPTION
## 📝 요약(Summary)

- 게시글 수정 페이지 구현.
- 게시글 수정 요청을 위한 라우트 핸들러 구현.

### `app/api/reviews/[reviewId]/route.ts`
**1. Mock API**
- Mock 데이터를 업데이트 후 revalidateTag 호출로 캐시 무효화.

**2. 실제 요청부**
- 리뷰 수정 요청 시 accessToken을 통한 사용자 세션 검증 후 백엔드로 PATCH 요청.
- 성공 시 revalidateTag로 'review-[reviewId]' 태그에 해당하는 게시글 본문 영역의 데이터 캐시 무효화.
- reviewId, 토큰 누락, 백엔드 측 오류 등에 대한 예외 처리 및 에러 응답 추가.

### `src/entities/review/apis/api-service.ts`
- `patchReview`: 전달된 reviewId를 사용해 요청 본문에 리뷰 데이터를 담아 Next.js 서버(/api/reviews/[reviewId])로 수정 요청.

### `src/entities/review/model/usePatchReview.ts`
- `useMutation`을 통한 서버 상태 변경.
- `onSuccess`: 
  - 요청 성공 시 요청 성공 토스트 알림 제공.
  - 사용자가 선택한 카테고리와 전체 영역에 해당하는 데이터의 캐시 무효화.
  - 사용자가 수정한 게시글에 해당하는 상세 페이지로 리다이렉트.

### `src/views/review/edit/ui/EditReviewPage.tsx`
- 전달된 `params`의 `reviewId`를 **number** 타입으로 변환.
- 쿠키 스토어의 `userEmail` 쿠키를 조회한 뒤, 쿠키가 없을 경우 비로그인 사용자로 판단해 에러 메세지 반환.
- `EditReview` 컴포넌트를 `Suspense` 바운더리로 캐싱 데이터가 없어 요청이 이루어질 경우 로딩 스피너 표시.
- `EditReview` 컴포넌트로 변환된 `reviewId`와 `userEmail` 쿠키의 값을 전달.

### `src/views/review/edit/ui/EditReview.tsx`
- 전달된 `reviewId`를 사용해 게시글 본문 영역 데이터 요청(`getReviewDetail`).
- 게시글 본문의 `author`와 `EditReview` 컴포넌트의 인자로 전달된 `sessionUserEmail` 값을 비교해 작성자 판단.
- `EditReviewClient` 컴포넌트로 게시글 본문 데이터와 `reviewId` 전달.

### `src/views/review/edit/ui/EditReviewClient.tsx`
- `usePatchReview` 훅을 호출해 `mutate` 함수와 `isPending` 값 반환.
- `handlePatchReview` 함수로 `mutate` 함수 래핑.
- `Editor` 컴포넌트로 초기값, `onSave` 콜백, `isPending` 값 전달.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가

## 📸스크린샷

<div align="center">

| 게시글 수정 |
| -- |
| <img src="https://github.com/user-attachments/assets/72a2b768-b6fc-4062-a169-9fbea84c6b6e" width="600px" /> |

</div>

## 💬 공유사항 to 리뷰어

- #18 

```typescript
const res = await fetch(url, {
  method: 'GET',
  next: {
    revalidate: false,
    tags: [`review-${reviewId}`],
  },
});
```
이전에 해당 풀 리퀘스트의 공유사항에 적었던 코드로 `reviewId`를 태그로 사용해 서버 단에서 게시글 본문 영역에 해당하는 데이터를 무기한 캐싱 중이었는데요.

이 데이터의 캐시를 무효화해야하는 시점이 언제일까요? 당연하게도 작성자가 게시글을 수정한 시점입니다. 그 외에는 무효화할 필요가 없다고 생각하고 있어요.

그래서 이번 작업에서 on-demand 방식으로 캐시를 무효화하는 방법을 사용했는데요. 먼저 [공식문서](https://nextjs.org/docs/app/guides/incremental-static-regeneration#on-demand-revalidation-with-revalidatetag)의 내용에 따르면 이 `revalidateTag`는 **Server Actions** 혹은 **Route Handler**에서만 사용이 가능하다고 해요.

게시글 수정 요청을 `useMutation`을 통해 호출하는데, 어떻게 `revalidateTag`를 조합해서 사용할 수 있을까? 고민을 해봤는데요. 고민 끝에 나온 방법은 바로 Next.js의 라우트 핸들러를 **미들웨어**로 사용하기 입니다!

현재 게시글 수정 요청은 이런 흐름을 가지고 있어요.
```
                                      ┌ (PATCH /reviews/[reviewId])
클라이언트단 브라우저 => Next.js 서버 => 백엔드 서버
                      └ (PATCH /api/reviews/[reviewId])
```
이렇게 클라이언트가 브라우저에서 저장 버튼을 클릭하면 실제로 요청은 **Next.js 서버**로 이동하고, 여기서 **백엔드 서버**로 실제 요청을 보낸 뒤, 요청이 성공하면 `revalidateTag`를 호출하는 방식이에요.

### 그래서 미들웨어처럼 Next.js Route Handler를 쓴 이유는?
잘 정리해보자면 다음과 같아요.
- 캐시 무효화에 사용되는 `revalidateTag`는 프론트 서버(Next.js)만 할 수 있고, 백엔드 서버(Spring)는 할 수 없다.
- 만약 클라이언트에서 백엔드로 바로 `PATCH` 요청을 보내면, 캐시 무효화 트리거를 실행할 방법이 없다.
- 따라서 중간에 **Next.js Route Handler**에서 직접 캐시를 무효화한다. 즉, 캐시 태그 관리의 **통제권을 프론트 서버가 쥐고** 있는다.

### 이 구조가 무조건 옳은가?
그렇진 않다고 생각해요. 적당한 트레이드 오프가 있다고 생각하는데, 먼저 의견을 정리해볼게요.

단순히 브라우저에서 백엔드 서버로 바로 요청을 보내는 것과 다르게 이 구조에선 모든 수정 요청이 **Next.js 서버**를 거치게 돼요.

그럼 즉, 모든 요청에 **네트워크 홉**이 한 단계 늘어난다는 것인데요. 여기서 네트워크 홉은 출발지(브라우저)와 목적지(백엔드 서버) 사이의 경로를 뜻해요.

당연히 경로가 늘어나니 요청에 걸리는 시간은 늘어나겠죠? 하지만 수정 요청과 본문 영역의 요청의 양을 비교해보면 당연히 본문 영역의 요청이 월등히 많을 거예요.

아무래도 게시글을 수정하는 행동보단, 누군가의 게시글을 열람하는 행동이 더 많을 테니까요.

그럼 게시글을 수정하지 않는 한 무기한으로 캐싱해 빠르게 게시글 데이터를 제공하는 것이 이득일 수 있겠다고 판단했어요.

결국 이 구조의 목적은요.
- 요청이 자주 일어나는 본문 조회는 최대한 빠르게 캐싱된 데이터를 제공하고, 자주 일어나지 않는 수정/삭제 요청만 **Next.js**를 거쳐 캐시된 데이터를 **on-demand** 방식으로 정확하게 무효화하는 것에 있어요.

즉, 수정의 비용을 약간 감수하고, 절대적으로 많은 읽기 트래픽에서 응답 속도를 높이고 서버의 부하 감소를 얻는 구조라고 볼 수 있어요.