### PR TITLE
(게시글 상세보기 페이지) - Feat/게시글 수정 버튼 구현

### DIFF
--- a/src/shared/lib/utils/getSessionUserEmail.ts
+++ b/src/shared/lib/utils/getSessionUserEmail.ts
@@ -1,0 +1,8 @@
+import {cookies} from 'next/headers';
+
+export default async function getSessionUserEmail() {
+  const cookieStore = await cookies();
+  const sessionUserEmail = cookieStore.get('userEmail');
+
+  return sessionUserEmail ? sessionUserEmail.value : null;
+}

--- a/src/views/review/detail/ui/ReviewDetailPage.tsx
+++ b/src/views/review/detail/ui/ReviewDetailPage.tsx
@@ -1,6 +1,8 @@
 import ReviewDetailInteractive from './ReviewDetailInteractive';
 import {Viewer} from '@/features/review/viewer';
 import {getReviewDetail} from '@/entities/review';
+import getSessionUserEmail from '@/shared/lib/utils/getSessionUserEmail';
+import Link from 'next/link';
 
 type Props = {
   params: Promise<{reviewId: string}>;
@@ -12,8 +14,20 @@ export default async function ReviewDetailPage({params}: Props) {
 
   const {author, content, category, created_at, title} = await getReviewDetail(parsedReviewId);
 
+  const sessionUserEmail = await getSessionUserEmail();
+  const isAuthor = sessionUserEmail === author;
+
   return (
-    <section className="flex flex-col w-full max-w-5xl mx-auto items-center">
+    <section className="flex flex-col w-full max-w-5xl mx-auto items-center relative">
+      {isAuthor && (
+        <div className="absolute top-[17px] right-6 flex items-center gap-2">
+          <Link href={`/reviews/${reviewId}/edit`} className="text-gray-500 hover:text-gray-700">
+            수정
+          </Link>
+          {/* TODO: 삭제 버튼 클릭 시 게시글 삭제 요청 구현하기 */}
+          <button className="text-gray-500 hover:text-gray-700">삭제</button>
+        </div>
+      )}
       <Viewer title={title} author={author} content={content} category={category} created_at={created_at} />
       <ReviewDetailInteractive reviewId={parsedReviewId} category={category} />
     </section>

--- a/src/views/review/edit/ui/EditReviewPage.tsx
+++ b/src/views/review/edit/ui/EditReviewPage.tsx
@@ -1,7 +1,7 @@
 import {Suspense} from 'react';
-import {cookies} from 'next/headers';
 import EditReview from './EditReview';
 import {LoadingSpinner} from '@/shared/ui/components';
+import getSessionUserEmail from '@/shared/lib/utils/getSessionUserEmail';
 
 type Props = {
   params: Promise<{reviewId: string}>;
@@ -11,8 +11,7 @@ export default async function ReviewEditPage({params}: Props) {
   const {reviewId} = await params;
   const parsedReviewId = Number(reviewId);
 
-  const cookieStore = await cookies();
-  const sessionUserEmail = cookieStore.get('userEmail');
+  const sessionUserEmail = await getSessionUserEmail();
 
   if (!sessionUserEmail) {
     throw new Error('로그인 세션이 만료되었습니다. 다시 로그인해주세요.');
@@ -21,7 +20,7 @@ export default async function ReviewEditPage({params}: Props) {
   return (
     <section className="fixed inset-0 bg-white">
       <Suspense fallback={<LoadingSpinner text="리뷰 정보를 불러오고 있어요." />}>
-        <EditReview reviewId={parsedReviewId} sessionUserEmail={sessionUserEmail.value} />
+        <EditReview reviewId={parsedReviewId} sessionUserEmail={sessionUserEmail} />
       </Suspense>
     </section>
   );


### PR DESCRIPTION
## 📝 요약(Summary)

- 게시글 작성자일 경우 게시글 본문 영역 상단 수정 및 삭제 버튼 표시.
- 게시글 수정 버튼 클릭 시 게시글 ID에 해당하는 수정 페이지로 리다이렉트.

### `src/shared/lib/utils/getSessionUserEmail.ts`
- 재사용 가능한 로그인 사용자 이메일 반환 함수 구현.
- 로그인 사용자일 경우 **httpOnly** 속성의 `userEmail` 쿠키의 `value`를 반환.

### `src/views/review/edit/ui/EditReviewPage.tsx`
- 게시글 수정 페이지의 로그인 세션 검사를 `getSessionUserEmail`의 반환 값으로 검사하도록 수정.

### `src/views/review/detail/ui/ReviewDetailPage.tsx`
- `getSessionUserEmail`의 반환 값과 게시글 본문 영역 데이터의 `author` 값을 비교해 `true/false` 값을 `isAuthor` 상수에 할당.
- 작성자일 경우 수정 및 삭제 버튼 표시.
- `Link` 태그 (수정) 클릭 시 `/reviews/[reviewid]/edit` 페이지로 클라이언트 사이드 네비게이션 수행.

## 🛠️ PR 유형

- [X] 새로운 기능 추가
- [X] 코드 리팩토링

## 📸스크린샷

<div align="center">

| 작성자 UI |
| -- |
| <img src="https://github.com/user-attachments/assets/6d03fde2-36ee-4e8e-90f6-2d491a0993c0" width="600px" /> |

| 일반 사용자 UI |
| -- |
| <img src="https://github.com/user-attachments/assets/0119074a-db47-45f1-b349-05a7c792f873" width="600px" /> |

| 수정 버튼 클릭 |
| -- |
| <img src="https://github.com/user-attachments/assets/3d4bacaf-04c4-4813-b6bc-08c9a247e76d" width="600px" /> |

</div>
