### PR TITLE
(게시글 상세보기 페이지) - Feat/게시글 삭제 기능 구현

### DIFF
--- a/app/api/reviews/[reviewId]/route.ts
+++ b/app/api/reviews/[reviewId]/route.ts
@@ -79,7 +79,7 @@ export async function PATCH(req: NextRequest, {params}: {params: Promise<{review
 }
 
 export async function DELETE() {
-  return NextResponse.json({}, {status: 204});
+  return NextResponse.json({status: 204});
 }
 
 // TODO: 백엔드 API 구현 완료 후 주석 해제

--- a/app/api/reviews/[reviewId]/route.ts
+++ b/app/api/reviews/[reviewId]/route.ts
@@ -1,6 +1,5 @@
 import {readFileSync, writeFileSync} from 'fs';
 import {revalidateTag} from 'next/cache';
-import {cookies} from 'next/headers';
 import {NextRequest, NextResponse} from 'next/server';
 import path from 'path';
 
@@ -79,6 +78,10 @@ export async function PATCH(req: NextRequest, {params}: {params: Promise<{review
   }
 }
 
+export async function DELETE() {
+  return NextResponse.json({}, {status: 204});
+}
+
 // TODO: 백엔드 API 구현 완료 후 주석 해제
 // export async function PATCH(req: NextRequest, {params}: {params: Promise<{reviewId: string}>}) {
 //   const {reviewId} = await params;
@@ -136,4 +139,59 @@ export async function PATCH(req: NextRequest, {params}: {params: Promise<{review
 
 //   revalidateTag(`review-${reviewId}`);
 //   return NextResponse.json({status: 201});
+// }
+
+// export async function DELETE(_: NextRequest, {params}: {params: Promise<{reviewId: string}>}) {
+//   const {reviewId} = await params;
+
+//   if (!reviewId) {
+//     return NextResponse.json(
+//       {
+//         errorCode: 'REVIEW_ID_MISSING',
+//         message: '리뷰 ID가 제공되지 않았습니다.',
+//       },
+//       {
+//         status: 400,
+//       },
+//     );
+//   }
+
+//   const cookieStore = await cookies();
+//   const accessToken = cookieStore.get('accessToken');
+
+//   if (!accessToken) {
+//     return NextResponse.json(
+//       {
+//         errorCode: 'UNAUTHORIZED',
+//         message: '로그인이 필요합니다.',
+//       },
+//       {
+//         status: 401,
+//       },
+//     );
+//   }
+
+//   const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/reviews/${reviewId}`, {
+//     method: 'DELETE',
+//     headers: {
+//       'Content-Type': 'application/json',
+//       Cookie: `accessToken=${accessToken.value}`,
+//     },
+//   });
+
+//   if (!res.ok) {
+//     const errorData = await res.json();
+//     return NextResponse.json(
+//       {
+//         errorCode: errorData.errorCode || 'INTERNAL_SERVER_ERROR',
+//         message: errorData.message || '서버 오류가 발생했습니다.',
+//       },
+//       {
+//         status: res.status,
+//       },
+//     );
+//   }
+
+//   revalidateTag(`review-${reviewId}`);
+//   return NextResponse.json({}, {status: 204});
 // }

--- a/src/entities/review/apis/api-service.ts
+++ b/src/entities/review/apis/api-service.ts
@@ -8,7 +8,7 @@ import {
   ReviewPayload,
   UploadImageProps,
 } from '../model/type';
-import {requestGet, requestPatch, requestPost} from '@/shared/apis';
+import {requestDelete, requestGet, requestPatch, requestPost} from '@/shared/apis';
 import {createClientError} from '@/shared/lib/utils/client-error';
 import {TErrorInfo} from '@/shared/apis/request-type';
 import {RequestGetError} from '@/shared/apis/request-error';
@@ -27,6 +27,13 @@ export async function patchReview(data: ReviewPayload, reviewId: number) {
     baseUrl: process.env.NEXT_PUBLIC_CLIENT_URL,
     endpoint: `/api/reviews/${reviewId}`,
     body: data,
+  });
+}
+
+export async function deleteReview(reviewId: number) {
+  await requestDelete({
+    baseUrl: process.env.NEXT_PUBLIC_CLIENT_URL,
+    endpoint: `/api/reviews/${reviewId}`,
   });
 }
 

--- a/src/entities/review/model/useDeleteReview.ts
+++ b/src/entities/review/model/useDeleteReview.ts
@@ -1,0 +1,37 @@
+'use client';
+
+import {useMutation, useQueryClient} from '@tanstack/react-query';
+import {useRouter} from 'next/navigation';
+import {deleteReview} from '../apis/api-service';
+import {Category} from './type';
+import toast from '@/shared/lib/utils/toastService';
+
+type MutationVariables = {
+  category: Category;
+  reviewId: number;
+};
+
+export default function useDeleteReview() {
+  const queryClient = useQueryClient();
+  const router = useRouter();
+
+  const {mutate, ...rest} = useMutation({
+    mutationFn: ({category, reviewId}: MutationVariables) => deleteReview(reviewId),
+    onSuccess: (_data, {category, reviewId}) => {
+      toast.success({
+        title: '리뷰를 성공적으로 삭제했어요.',
+      });
+
+      // TODO: reviewQueryKeys => reviewsQueryKeys로 변경 후 주석 해제
+      // queryClient.invalidateQueries(reviewQueryKeys.search(category, 'recent'));
+      // queryClient.invalidateQueries(reviewQueryKeys.search('all', 'recent'));
+
+      router.push('/search');
+    },
+  });
+
+  return {
+    deleteReview: mutate,
+    ...rest,
+  };
+}

--- a/src/entities/reviews/index.ts
+++ b/src/entities/reviews/index.ts
@@ -10,3 +10,4 @@ export {default as useMyReviews} from './model/useMyReviews';
 export {default as useMyBookmarkedReviews} from './model/useMyBookmarkedReviews';
 export {default as ReviewsGridLoading} from './ui/ReviewsGridLoading';
 export {default as NoSearchResults} from './ui/NoSearchResults';
+export {default as DeleteButton} from './ui/DeleteButton';

--- a/src/entities/reviews/ui/DeleteButton.tsx
+++ b/src/entities/reviews/ui/DeleteButton.tsx
@@ -34,7 +34,7 @@ export default function DeleteButton({category, reviewId}: Props) {
       </button>
       {isPending && (
         <section className="fixed inset-0 z-50 bg-black/70">
-          <LoadingSpinner text="리뷰를 삭제 중이에요." />
+          <LoadingSpinner text="리뷰를 삭제 중이에요." className="text-white" />
         </section>
       )}
     </>

--- a/src/entities/reviews/ui/DeleteButton.tsx
+++ b/src/entities/reviews/ui/DeleteButton.tsx
@@ -29,7 +29,14 @@ export default function DeleteButton({category, reviewId}: Props) {
 
   return (
     <>
-      <button className="text-gray-500 hover:text-gray-700" onClick={handleDelete} disabled={isPending}>
+      <button
+        className="text-gray-500 hover:text-gray-700"
+        onClick={handleDelete}
+        disabled={isPending}
+        tabIndex={isPending ? -1 : 0}
+        aria-label="리뷰 삭제"
+        aria-disabled={isPending}
+      >
         삭제
       </button>
       {isPending && (

--- a/src/entities/reviews/ui/DeleteButton.tsx
+++ b/src/entities/reviews/ui/DeleteButton.tsx
@@ -2,6 +2,8 @@
 
 import {Category} from '@/entities/review/model/type';
 import useDeleteReview from '@/entities/review/model/useDeleteReview';
+import {LoadingSpinner} from '@/shared/ui/components';
+import {useEffect} from 'react';
 
 type Props = {
   category: Category;
@@ -15,9 +17,26 @@ export default function DeleteButton({category, reviewId}: Props) {
     deleteReview({category, reviewId});
   };
 
+  useEffect(() => {
+    const prevHtmlOverflow = document.documentElement.style.overflow;
+
+    if (isPending) {
+      document.documentElement.style.overflow = 'hidden';
+    } else {
+      document.documentElement.style.overflow = prevHtmlOverflow;
+    }
+  }, [isPending]);
+
   return (
-    <button className="text-gray-500 hover:text-gray-700" onClick={handleDelete} disabled={isPending}>
-      {isPending ? '삭제 중' : '삭제'}
-    </button>
+    <>
+      <button className="text-gray-500 hover:text-gray-700" onClick={handleDelete} disabled={isPending}>
+        삭제
+      </button>
+      {isPending && (
+        <section className="fixed inset-0 z-50 bg-black/70">
+          <LoadingSpinner text="리뷰를 삭제 중이에요." />
+        </section>
+      )}
+    </>
   );
 }

--- a/src/entities/reviews/ui/DeleteButton.tsx
+++ b/src/entities/reviews/ui/DeleteButton.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import {Category} from '@/entities/review/model/type';
+import useDeleteReview from '@/entities/review/model/useDeleteReview';
+
+type Props = {
+  category: Category;
+  reviewId: number;
+};
+
+export default function DeleteButton({category, reviewId}: Props) {
+  const {deleteReview, isPending} = useDeleteReview();
+
+  const handleDelete = () => {
+    deleteReview({category, reviewId});
+  };
+
+  return (
+    <button className="text-gray-500 hover:text-gray-700" onClick={handleDelete} disabled={isPending}>
+      {isPending ? '삭제 중' : '삭제'}
+    </button>
+  );
+}

--- a/src/shared/ui/components/LoadingSpinner.tsx
+++ b/src/shared/ui/components/LoadingSpinner.tsx
@@ -1,12 +1,14 @@
+import {cn} from '@/shared/lib/utils/cn';
 import {LucideIcon} from '../icons';
 
 type Props = {
   text?: string;
+  className?: HTMLDivElement['className'];
 };
 
-export default function LoadingSpinner({text}: Props) {
+export default function LoadingSpinner({text, className}: Props) {
   return (
-    <section className="w-full h-full flex flex-col justify-center items-center animate-pulse">
+    <section className={cn('w-full h-full flex flex-col justify-center items-center animate-pulse', className)}>
       {text && <p className="text-xl md:text-2xl font-semibold mb-4">{text}</p>}
       <LucideIcon name="Disc3" className="animate-spin w-[40px] h-[40px] md:w-[45px] md:h-[45px]" />
     </section>

--- a/src/views/review/detail/ui/ReviewDetailPage.tsx
+++ b/src/views/review/detail/ui/ReviewDetailPage.tsx
@@ -1,5 +1,6 @@
 import ReviewDetailInteractive from './ReviewDetailInteractive';
 import {Viewer} from '@/features/review/viewer';
+import {DeleteButton} from '@/entities/reviews';
 import {getReviewDetail} from '@/entities/review';
 import getSessionUserEmail from '@/shared/lib/utils/getSessionUserEmail';
 import Link from 'next/link';
@@ -24,8 +25,7 @@ export default async function ReviewDetailPage({params}: Props) {
           <Link href={`/reviews/${reviewId}/edit`} className="text-gray-500 hover:text-gray-700">
             수정
           </Link>
-          {/* TODO: 삭제 버튼 클릭 시 게시글 삭제 요청 구현하기 */}
-          <button className="text-gray-500 hover:text-gray-700">삭제</button>
+          <DeleteButton category={category} reviewId={parsedReviewId} />
         </div>
       )}
       <Viewer title={title} author={author} content={content} category={category} created_at={created_at} />


### PR DESCRIPTION
## 📝 요약(Summary)

- 게시글 상세보기 페이지 내 작성자일 경우 수정 및 삭제 버튼 표시.
- 삭제 버튼 클릭 시 삭제 요청.
- 삭제 성공 시 게시글 검색 페이지로 리다이렉트.

### `app/api/reviews/[reviewId]/route.ts`
**1. Mock API**
- 성공 응답 리턴.

**2. 실제 요청부**
- 리뷰 삭제 요청 시 accessToken을 통한 사용자 세션 검증 후 백엔드로 DELETE 요청.
- 성공 시 revalidateTag로 'review-[reviewId]' 태그에 해당하는 게시글 본문 영역의 데이터 캐시 무효화.
- reviewId, 토큰 누락, 백엔드 측 오류 등에 대한 예외 처리 및 에러 응답 추가.

### `src/entities/review/apis/api-service.ts`
- `deleteReview`: 전달된 reviewId를 사용해 요청 본문에 리뷰 데이터를 담아 Next.js 서버(/api/reviews/[reviewId])로 삭제 요청.

### `src/entities/review/model/useDeleteReview.ts`
- `useMutation`을 통한 서버 상태 변경.
- `onSuccess`:
  - 요청 성공 시 요청 성공 토스트 알림 제공 및 검색 페이지로 리다이렉트.
  - 사용자가 작성한 카테고리 및 전체 영역에 해당하는 리뷰 데이터 캐시 무효화.

### `src/entities/reviews/ui/DeleteButton.tsx`
- useDeleteReview 훅을 호출해 mutate 함수와 제출 상태값 반환.
- 제출 상태(isPending)일 경우 화면을 가득 채우는 로딩 오버레이 표시.
- 제출 상태 값에 따라 스크롤 락.

### `src/views/review/detail/ui/ReviewDetailPage.tsx`
- #29 와 동일하게 작성자 판단 후 렌더링되는 영역에 `DeleteButton` 컴포넌트 추가.

## 🛠️ PR 유형

- [X] 새로운 기능 추가

## 📸스크린샷

<div align="center">

| 게시글 삭제 |
| -- |
| <img src="https://github.com/user-attachments/assets/a21e21b2-58b8-4a0e-bdf7-e99c89c94e70" width="600px" /> |

</div>