### PR TITLE
(마이페이지) - Feat/게시글 수정 기능 연결

### DIFF
--- a/src/entities/reviews/ui/CardFrame.tsx
+++ b/src/entities/reviews/ui/CardFrame.tsx
@@ -31,7 +31,6 @@ type MyPageProps = BaseProps & {
   from: 'myPage';
   isAuthor: boolean;
   reviewId: string;
-  onEdit: () => void;
   onDelete: () => void;
 };
 

--- a/src/entities/reviews/ui/CardFrame.tsx
+++ b/src/entities/reviews/ui/CardFrame.tsx
@@ -3,6 +3,7 @@ import {ReviewCard} from '@/entities/review';
 import CardDescription from './CardDescription';
 import {cn} from '@/shared/lib/utils/cn';
 import {LucideIcon} from '@/shared/ui/icons';
+import Link from 'next/link';
 
 const cardVariants = cva('relative bg-white', {
   variants: {
@@ -29,6 +30,7 @@ type BestReviewsProps = BaseProps & {
 type MyPageProps = BaseProps & {
   from: 'myPage';
   isAuthor: boolean;
+  reviewId: string;
   onEdit: () => void;
   onDelete: () => void;
 };
@@ -38,7 +40,7 @@ type ReviewCardProps = BestReviewsProps | MyPageProps;
 type Props = ReviewCardProps & VariantProps<typeof cardVariants>;
 
 export default function CardFrame(props: Props) {
-  const {card, from, className, onEdit, onDelete} = props;
+  const {card, from, className, onDelete} = props;
 
   function renderCard() {
     switch (from) {
@@ -49,9 +51,9 @@ export default function CardFrame(props: Props) {
           <>
             {props.isAuthor && (
               <div className="absolute w-full px-4 pt-1 flex justify-between">
-                <button onClick={onEdit} aria-label="리뷰 수정">
+                <Link href={`/reviews/${props.reviewId}/edit`} aria-label="리뷰 수정">
                   <LucideIcon name="PencilLine" size={20} />
-                </button>
+                </Link>
                 <button onClick={onDelete} aria-label="리뷰 삭제">
                   <LucideIcon name="X" size={20} />
                 </button>

--- a/src/entities/reviews/ui/ReviewsGrid.tsx
+++ b/src/entities/reviews/ui/ReviewsGrid.tsx
@@ -23,14 +23,12 @@ type Props =
       reviews: ReviewCard[];
       from: 'myReviews';
       onDelete: () => void;
-      onEdit: () => void;
     }
   | {
       reviews: ReviewCard[];
       from: 'myBookmarkedReviews';
       userId: string | null;
       onDelete: () => void;
-      onEdit: () => void;
     };
 
 export default function ReviewsGrid(props: Props) {
@@ -46,8 +44,8 @@ export default function ReviewsGrid(props: Props) {
             card={card}
             from="myPage"
             isAuthor={true}
+            reviewId={card.board_id}
             onDelete={props.onDelete}
-            onEdit={props.onEdit}
           />
         );
       case 'myBookmarkedReviews':
@@ -57,8 +55,8 @@ export default function ReviewsGrid(props: Props) {
             card={card}
             from="myPage"
             isAuthor={props.userId === card.author}
+            reviewId={card.board_id}
             onDelete={props.onDelete}
-            onEdit={props.onEdit}
           />
         );
       case 'bestReviews':

--- a/src/features/reviews/my/ui/MyBookmarkedReviews.tsx
+++ b/src/features/reviews/my/ui/MyBookmarkedReviews.tsx
@@ -17,13 +17,7 @@ export default function MyBookmarkedReviews({currentPage}: Props) {
 
   return (
     <section>
-      <ReviewsGrid
-        reviews={results}
-        from="myBookmarkedReviews"
-        userId={userId}
-        onEdit={() => console.log('수정')}
-        onDelete={() => console.log('삭제')}
-      />
+      <ReviewsGrid reviews={results} from="myBookmarkedReviews" userId={userId} onDelete={() => console.log('삭제')} />
       <Pagination
         currentPage={currentPage}
         totalPages={total_pages}

--- a/src/features/reviews/my/ui/MyReviews.tsx
+++ b/src/features/reviews/my/ui/MyReviews.tsx
@@ -15,12 +15,7 @@ export default function MyReviews({currentPage}: Props) {
 
   return (
     <section>
-      <ReviewsGrid
-        reviews={results}
-        from="myReviews"
-        onEdit={() => console.log('수정')}
-        onDelete={() => console.log('삭제')}
-      />
+      <ReviewsGrid reviews={results} from="myReviews" onDelete={() => console.log('삭제')} />
       <Pagination
         currentPage={currentPage}
         totalPages={total_pages}


### PR DESCRIPTION
## 📝 요약(Summary)

- 수정 버튼 클릭 시 해당 리뷰 수정 페이지로 이동.

### `src/entities/reivews/ui/CardFrame.tsx`
- onEdit 콜백을 여러 단계에 걸쳐 받지 않고, Link 태그로 즉시 전달된 reviewId에 해당하는 수정 페이지로 이동.

### `src/entities/reivews/ui/ReviewsGrid.tsx`
- from 값이 myReviews, myBookmarkedReviews일 경우 onEdit을 전달하지 않고, reviewId를 전달하도록 수정.

### `src/features/reviews/my/ui/MyReviews.tsx`
- onEdit 인자 제거.

### `src/features/reviews/my/ui/MyBookmarkedReviews.tsx`
- onEdit 인자 제거.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가
- [X] 코드 리팩토링

## 📸스크린샷

<div align="center">

| 수정 버튼 클릭 시 수정 페이지 이동 |
| -- |
| <img src="https://github.com/user-attachments/assets/6bbcb501-c415-40af-a3ec-fb18f6b0611f" width="600px" /> |

</div>