### PR TITLE
(공통) - Refactor/리뷰들에 대한 쿼리 키 팩터리 구조를 계층 구조로 변경

### DIFF
--- a/src/entities/reviews/index.ts
+++ b/src/entities/reviews/index.ts
@@ -11,3 +11,4 @@ export {default as useMyBookmarkedReviews} from './model/useMyBookmarkedReviews'
 export {default as ReviewsGridLoading} from './ui/ReviewsGridLoading';
 export {default as NoSearchResults} from './ui/NoSearchResults';
 export {default as DeleteButton} from './ui/DeleteButton';
+export {reviewsQueryKeys, reviewsQueryOptions} from './model/query-service';

--- a/src/entities/reviews/model/query-service.ts
+++ b/src/entities/reviews/model/query-service.ts
@@ -1,11 +1,5 @@
 import {keepPreviousData} from '@tanstack/react-query';
-import {
-  getBestReviews,
-  getCategoryReviews,
-  getKeywordReviews,
-  getMyBookmarkedReviews,
-  getMyReviews,
-} from '../apis/api-service';
+import {getCategoryReviews, getKeywordReviews, getMyBookmarkedReviews, getMyReviews} from '../apis/api-service';
 
 export const reviewsQueryKeys = {
   all: () => ['reviews'] as const,
@@ -31,22 +25,22 @@ export const reviewsQueryKeys = {
 
 export const reviewsQueryOptions = {
   category: (categoryId: string, sort: string) => ({
-    queryKey: reviewsQueryKeys.category(categoryId, sort),
+    queryKey: reviewsQueryKeys.category.page(categoryId, sort),
     queryFn: ({pageParam}: {pageParam: number}) => getCategoryReviews(pageParam, categoryId, sort),
     initialPageParam: 0,
   }),
   keyword: (keyword: string, page: number, sort: string) => ({
-    queryKey: reviewsQueryKeys.keyword(keyword, page, sort),
+    queryKey: reviewsQueryKeys.keyword.page(keyword, page, sort),
     queryFn: () => getKeywordReviews(keyword, page, sort),
     placeholderData: keepPreviousData,
   }),
   my: (page: number) => ({
-    queryKey: reviewsQueryKeys.my(page),
+    queryKey: reviewsQueryKeys.my.page(page),
     queryFn: () => getMyReviews(page),
     placeholderData: keepPreviousData,
   }),
   myBookmarks: (page: number) => ({
-    queryKey: reviewsQueryKeys.myBookmarks(page),
+    queryKey: reviewsQueryKeys.myBookmarks.page(page),
     queryFn: () => getMyBookmarkedReviews(page),
     placeholderData: keepPreviousData,
   }),

--- a/src/entities/reviews/model/query-service.ts
+++ b/src/entities/reviews/model/query-service.ts
@@ -8,11 +8,19 @@ import {
 } from '../apis/api-service';
 
 export const reviewsQueryKeys = {
-  best: ['best'] as const,
-  category: (categoryId: string, sort: string) => ['category', categoryId, sort] as const,
-  keyword: (keyword: string, page: number, sort: string) => ['keyword', keyword, page, sort] as const,
-  my: (page: number) => ['my', page] as const,
-  myBookmarks: (page: number) => ['myBookmarks', page] as const,
+  // 베이스 키 (depth1)
+  all: () => ['reviews'] as const,
+  my: () => [...reviewsQueryKeys.all(), 'my'] as const,
+  myBookmarks: () => [...reviewsQueryKeys.all(), 'myBookmarks'] as const,
+  keyword: () => [...reviewsQueryKeys.all(), 'keyword'] as const,
+  category: () => [...reviewsQueryKeys.all(), 'category'] as const,
+  best: () => [...reviewsQueryKeys.all(), 'best'] as const,
+
+  // best: ['best'] as const,
+  // category: (categoryId: string, sort: string) => ['category', categoryId, sort] as const,
+  // keyword: (keyword: string, page: number, sort: string) => ['keyword', keyword, page, sort] as const,
+  // my: (page: number) => ['my', page] as const,
+  // myBookmarks: (page: number) => ['myBookmarks', page] as const,
 };
 
 export const reviewsQueryOptions = {

--- a/src/entities/reviews/model/query-service.ts
+++ b/src/entities/reviews/model/query-service.ts
@@ -10,9 +10,6 @@ import {
 export const reviewsQueryKeys = {
   all: () => ['reviews'] as const,
 
-  best: {
-    all: () => [...reviewsQueryKeys.all(), 'best'] as const,
-  },
   my: {
     all: () => [...reviewsQueryKeys.all(), 'my'] as const,
     page: (page: number) => [...reviewsQueryKeys.my.all(), page] as const,
@@ -34,10 +31,6 @@ export const reviewsQueryKeys = {
 };
 
 export const reviewsQueryOptions = {
-  best: () => ({
-    queryKey: reviewsQueryKeys.best,
-    queryFn: getBestReviews,
-  }),
   category: (categoryId: string, sort: string) => ({
     queryKey: reviewsQueryKeys.category(categoryId, sort),
     queryFn: ({pageParam}: {pageParam: number}) => getCategoryReviews(pageParam, categoryId, sort),

--- a/src/entities/reviews/model/query-service.ts
+++ b/src/entities/reviews/model/query-service.ts
@@ -25,8 +25,7 @@ export const reviewsQueryKeys = {
   },
   category: {
     all: () => [...reviewsQueryKeys.all(), 'category'] as const,
-    page: (categoryId: string, sort: string, pageParam: number) =>
-      [...reviewsQueryKeys.category.all(), categoryId, sort, pageParam] as const,
+    page: (categoryId: string, sort: string) => [...reviewsQueryKeys.category.all(), categoryId, sort] as const,
   },
 };
 

--- a/src/entities/reviews/model/query-service.ts
+++ b/src/entities/reviews/model/query-service.ts
@@ -8,19 +8,29 @@ import {
 } from '../apis/api-service';
 
 export const reviewsQueryKeys = {
-  // 베이스 키 (depth1)
   all: () => ['reviews'] as const,
-  my: () => [...reviewsQueryKeys.all(), 'my'] as const,
-  myBookmarks: () => [...reviewsQueryKeys.all(), 'myBookmarks'] as const,
-  keyword: () => [...reviewsQueryKeys.all(), 'keyword'] as const,
-  category: () => [...reviewsQueryKeys.all(), 'category'] as const,
-  best: () => [...reviewsQueryKeys.all(), 'best'] as const,
 
-  // best: ['best'] as const,
-  // category: (categoryId: string, sort: string) => ['category', categoryId, sort] as const,
-  // keyword: (keyword: string, page: number, sort: string) => ['keyword', keyword, page, sort] as const,
-  // my: (page: number) => ['my', page] as const,
-  // myBookmarks: (page: number) => ['myBookmarks', page] as const,
+  best: {
+    all: () => [...reviewsQueryKeys.all(), 'best'] as const,
+  },
+  my: {
+    all: () => [...reviewsQueryKeys.all(), 'my'] as const,
+    page: (page: number) => [...reviewsQueryKeys.my.all(), page] as const,
+  },
+  myBookmarks: {
+    all: () => [...reviewsQueryKeys.all(), 'myBookmarks'] as const,
+    page: (page: number) => [...reviewsQueryKeys.myBookmarks.all(), page] as const,
+  },
+  keyword: {
+    all: () => [...reviewsQueryKeys.all(), 'keyword'] as const,
+    page: (keyword: string, page: number, sort: string) =>
+      [...reviewsQueryKeys.keyword.all(), keyword, page, sort] as const,
+  },
+  category: {
+    all: () => [...reviewsQueryKeys.all(), 'category'] as const,
+    page: (categoryId: string, sort: string, pageParam: number) =>
+      [...reviewsQueryKeys.category.all(), categoryId, sort, pageParam] as const,
+  },
 };
 
 export const reviewsQueryOptions = {


### PR DESCRIPTION
## 📝 요약(Summary)

### 배경
마이페이지에서 리뷰 삭제 기능을 구현하던 중, **페이지네이션된 리뷰 데이터의 캐시 무효화가 지나치게 비효율적**인 문제를 발견했습니다.

예전 구조는 `['my', page]` 처럼 페이지별로 평면적으로 쿼리 키를 만들고 각 페이지마다 데이터를 캐싱하는 구조였어요.

예를 들어 6페이지까지 리뷰가 있으면 아래처럼 각각의 캐시가 쌓입니다.
```typescript
const reviewQueryKeys = {
  my: (page: number) => ['my', page] as const,
}

['my', 1]
['my', 2]
['my', 3]
['my', 4]
['my', 5]
['my', 6]
```
여기서 1페이지에서 리뷰를 삭제하면, 실제로는 모든 페이지의 데이터가 앞으로 한 칸씩 당겨지며 데이터 불일치가 발생합니다.

이 때, 페이지 수가 유동적이라서 몇 개의 캐시를 무효화해야 할지 예측하기 어렵고, 결국 모든 페이지 캐시를 한 번에 무효화해야만 합니다.

리액트 쿼리 공식문서를 찾아보면, 계층적 무효화 방법으로 상위 키를 지정해 `invalidateQueries`를 호출하면 상위 키를 접두사로 가지는 모든 하위 키들이 무효화된다고 나와있어요.
```typescript
export const reviewsQueryKeys = {
  my: {
    all: () => ['reviews', 'my'] as const,
    page: (page: number) => [...reviewsQueryKeys.my.all(), page] as const,
  },
};

queryClient.invalidateQueries({
  queryKey: reviewsQueryKeys.my.all(),
});
```
위의 구조에선 캐시 키가 `['reviews', 'my', 1]`, `['reviews', 'my', 2]` 처럼 계층적으로 생성되는데요.

이 상태에서 `['reviews', 'my']`만 무효화해주면 하위의 모든 페이지 캐시가 한 번에 무효화됩니다.

### 변경사항
- 쿼리 키를 평면 구조에서 계층 구조로 변경.
- `.all()`: 상위 무효화용 베이스 키.
- `.page()`: 상세 조건별 키.
- 마이페이지 같은 특수한 상황의 경우 .`all()`을 사용해 무효화


## 🛠️ PR 유형

- [X] 코드 리팩토링