### PR TITLE
(게시글 상세보기 페이지) - Fix/북마크 상태와 반대로 요청하던 문제 해결

### DIFF
--- a/src/entities/review/model/useToggleBookmark.ts
+++ b/src/entities/review/model/useToggleBookmark.ts
@@ -3,14 +3,15 @@ import {reviewQueryKeys} from './query-service';
 import {BookmarkPayload, ReviewBookmarks} from './type';
 import {useMutation, useQueryClient} from '@tanstack/react-query';
 
+type MutationVariables = {
+  hasBookmarked: boolean;
+} & BookmarkPayload;
+
 export default function useToggleBookmark() {
   const queryClient = useQueryClient();
 
   const {mutate, ...rest} = useMutation({
-    mutationFn: ({userEmail, reviewId}: BookmarkPayload) => {
-      const currentData = queryClient.getQueryData<ReviewBookmarks>(reviewQueryKeys.bookmarks(reviewId));
-      const hasBookmarked = currentData && currentData.hasBookmarked;
-
+    mutationFn: ({userEmail, reviewId, hasBookmarked}: MutationVariables) => {
       if (hasBookmarked) {
         return unBookmarkReview({userEmail, reviewId});
       } else {

--- a/src/entities/review/model/useToggleBookmark.ts
+++ b/src/entities/review/model/useToggleBookmark.ts
@@ -44,8 +44,18 @@ export default function useToggleBookmark() {
     },
   });
 
+  const toggleBookmark = (payload: BookmarkPayload) => {
+    const currentData = queryClient.getQueryData<ReviewBookmarks>(reviewQueryKeys.bookmarks(payload.reviewId));
+    const hasBookmarked = currentData ? currentData.hasBookmarked : false;
+
+    mutate({
+      ...payload,
+      hasBookmarked,
+    });
+  };
+
   return {
-    toggleBookmark: mutate,
+    toggleBookmark,
     ...rest,
   };
 }


### PR DESCRIPTION
## 리액트 쿼리의 낙관적 업데이트로 인한 북마크 토글 버그
### 들어가며..
리액트 쿼리의 `useMutation`을 사용한 서버 상태 변경, `onMutate` 콜백을 통한 **낙관적 업데이트**를 사용해 북마크 기능을 구현하던 중, 의도와 반대로 API 요청이 호출되는 버그를 발견했습니다. 

이번 풀 리퀘스트는 버그의 원인이었던 `onMutate`와 `mutationFn`의 실행 순서를 확인하며 문제를 분석하고 역할 분리를 통해 코드를 개선한 과정을 공유하고자 합니다.

### 문제 상황
사용자가 특정 게시글을 북마크 중인 상태에서 버튼을 클릭하면 북마크를 **해제**해야 하지만, 다시 북마크 **요청**을 보내는 문제가 발생했습니다. 반대의 경우도 마찬가지였습니다.

### 분석
북마크 로직은 낙관적 업데이트를 적용해 요청을 보낸 시점에 요청의 성공을 기대한 미래의 UI를 제공 중이었는데요.

먼저 버그를 이해하려면 `useMutation`의 동작, 특히 `onMutate`가 실행되는 시점을 아는 것이 중요한데요.
```typescript
const {mutate, ...rest} = useMutation({
  mutationFn: ({userEmail, reviewId}: BookmarkPayload) => {
    const currentData = queryClient.getQueryData<ReviewBookmarks>(reviewQueryKeys.bookmarks(reviewId));

    const hasBookmarked = currentData && !currentData.hasBookmarked;

    if (hasBookmarked) {
      return unBookmarkReview({userEmail, reviewId});
    } else {
      return bookmarkReview({userEmail, reviewId});
    }
  },

  onMutate: async ({reviewId}) => {
    await queryClient.cancelQueries({queryKey: reviewQueryKeys.bookmarks(reviewId)});

    const previousBookmarks = queryClient.getQueryData<ReviewBookmarks>(reviewQueryKeys.bookmarks(reviewId));

    if (previousBookmarks) {
      const updatedBookmarks: ReviewBookmarks = {
        bookmarks: previousBookmarks.bookmarks + (previousBookmarks.hasBookmarked ? -1 : 1),

        hasBookmarked: !previousBookmarks.hasBookmarked,
      };

      queryClient.setQueryData(reviewQueryKeys.bookmarks(reviewId), updatedBookmarks);
    }

    return {previousBookmarks};
  },

  onSuccess: (_, {reviewId}) => {
    queryClient.invalidateQueries({queryKey: reviewQueryKeys.bookmarks(reviewId)});
  },

  onError: (_, {reviewId}, context) => {
    if (context) {
      queryClient.setQueryData(reviewQueryKeys.bookmarks(reviewId), context.previousBookmarks);
    }
  },
});
```
- 외부에서 `useMutation` 훅을 호출해 만들어진 `mutate` 함수가 호출 돼요.
- 그럼 가장 먼저 `onMutate` 콜백이 실행되는데요. **실제로 서버에 요청을 보내기 직전에 실행되는 사전 작업**이라고 이해하면 돼요.
```typescript
await queryClient.cancelQueries({queryKey: reviewQueryKeys.bookmarks(reviewId)});
```
- `queryClient.cancelQueries`로 무언가 이 북마크 데이터를 다시 불러온다던가, 혹은 다른 백그라운드 요청이 진행 중이라면 그 요청을 취소해요.
- 사용자에게 보여줄 UI를 낙관적으로 바로 업데이트할 건데, 혹시 다른 작업으로 인해 **다른 결과로 덮어쓰이는 것을 방지**하기 위해서예요.

```typescript
const previousBookmarks = queryClient.getQueryData<ReviewBookmarks>(reviewQueryKeys.bookmarks(reviewId));
```
- `queryClient.getQueryData`를 호출해 UI를 바꾸기 직전, 현재 캐싱 중인 데이터를 `previousBookmarks` 변수에 저장해요.
- 혹시 요청이 실패해 데이터를 롤백해야만 하는 상황이 올 수 있어 그 때 사용할 **세이브 포인트**라고 이해하면 돼요.

```typescript
if (previousBookmarks) {
  const updatedBookmarks: ReviewBookmarks = {
    bookmarks: previousBookmarks.bookmarks + (previousBookmarks.hasBookmarked ? -1 : 1),

    hasBookmarked: !previousBookmarks.hasBookmarked,
  };

  queryClient.setQueryData(reviewQueryKeys.bookmarks(reviewId), updatedBookmarks);
}
```
- 이제 `previousBookmarks` 값이 존재한다면, 낙관적 업데이트를 실행하는데요.
- `previousBookmarks`의 `hasBookmarked` 값이 `true`일 경우 사용자는 북마크를 취소하기 위해 버튼을 클릭했을테니 `hasBookmarked` 값을 `false`로, 북마크 카운트를 1 감소시켜요.
- 반대로 `hasBookmarked` 값이 `false`라면, 사용자는 북마크 요청을 위해 버튼을 클릭했으니 `hasBookmarked` 값을 `true`, 북마크 카운트를 1 증가시켜요.
- 마지막으로 `setQueryData`를 호출해 캐시를 이 `updatedBookmarks` 값으로 덮어씌워요.

```typescript
return {previousBookmarks};
```
- 그리고 혹시 실패할 경우를 대비해 롤백을 위한 세이브 포인트인 `previousBookmarks` 값을 `return`하며 종료해요.
- 여기서 `return`한 값은 `onError`, `onSuccess` 콜백 등에서 3번째 인자인 `context` 값으로 전달 돼요.

위에서 설명한 작업(`onMutate`)들이 모두 실행된 이후 `mutationFn` 콜백이 실행되어 실제 서버 API를 호출하게 됩니다. 여기서 문제가 발생하는데요.
```typescript
mutationFn: ({userEmail, reviewId}: BookmarkPayload) => {
    const currentData = queryClient.getQueryData<ReviewBookmarks>(reviewQueryKeys.bookmarks(reviewId));

    const hasBookmarked = currentData && currentData.hasBookmarked;

    if (hasBookmarked) {
      return unBookmarkReview({userEmail, reviewId});
    } else {
      return bookmarkReview({userEmail, reviewId});
    }
},
```
`mutationFn`이 조회한 데이터는 이미 `onMutate`에 의해 미리 변경된 **미래**의 상태입니다. 사용자가 북마크를 추가(`hasBookmarked: false` => `true`)하려고 클릭했음에도, 

`mutationFn`은 캐시에 저장된 `true` 값을 보고 북마크 해제(`unBookmarkReview`) API를 호출하게 됩니다.

### 개선 방안
`mutate` 함수가 호출되면, `mutationFn` 호출 전에 `onMutate`가 먼저 실행된다는 점을 알게 되었습니다. 

때문에 **현재 북마크 상태 조회와 북마크 상태 판단**을 `mutationFn`에서 분리하고 이 작업을 mutate 함수 호출 전에 실행해 인자로 전달하는 방법을 선택했습니다.

```typescript
type MutationVariables = {
  hasBookmarked: boolean;
} & BookmarkPayload;

mutationFn: ({userEmail, reviewId, hasBookmarked}: MutationVariables) => {
  if (hasBookmarked) {
    return unBookmarkReview({userEmail, reviewId});
  } else {
    return bookmarkReview({userEmail, reviewId});
  }
}
```
`mutationFn`은 이제 전달받은 `hasBookmarked` 값에 따라 API를 호출하는 **단순한 실행 책임**만 가집니다.

```typescript
const toggleBookmark = (payload: BookmarkPayload) => {
  // mutate가 실행되기 전 '현재' 상태를 먼저 조회.
  const currentData = queryClient.getQueryData<ReviewBookmarks>(reviewQueryKeys.bookmarks(payload.reviewId));
  const hasBookmarked = currentData ? currentData.hasBookmarked : false;
  
  // 조회한 현재 상태를 인자로 전달하며 mutate 함수를 호출.
  mutate({
    ...payload,
    hasBookmarked,
  });
};
```
외부에 노출되는 `toggleBookmark` 함수가 상태를 조회하고 판단하는 책임을 맡습니다.

이렇게 `toggleBookmark` 함수가 상태를 파악해 `mutate`를 호출하기 때문에 `onMutate` 콜백 전에 미래의 상태가 아닌 현재 상태를 정확히 파악할 수 있고,

`mutationFn`은 그저 전달받은 값으로 API를 실행하도록 역할을 명확히 분리함으로써 문제를 해결할 수 있었습니다.

## 마치며..
간단한 작업일 수 있지만, 낙관적 업데이트를 구현할 때, `onMutate`와 `mutationFn`의 데이터 흐름을 정확히 알아야 이런 실수가 생기지 않을 것 같아 공유 목적으로 조금 길게 작성하게 되었습니다..

읽어주셔서 감사해요......

## 🛠️ PR 유형

- [x] 버그 수정