### PR TITLE
(공통) - Refactor/모든 응답 데이터의 author 속성을 author_id, author_email로 세분화

### DIFF
--- a/src/entities/review/model/type.ts
+++ b/src/entities/review/model/type.ts
@@ -30,7 +30,8 @@ export type ReviewContent = {
 export type Comment = {
   id: number;
   profile_image: string;
-  author: string;
+  author_id: string;
+  author_email: string;
   content: string;
   created_at: string;
 };

--- a/src/entities/review/model/type.ts
+++ b/src/entities/review/model/type.ts
@@ -21,7 +21,8 @@ export type SearchReviewCard = ReviewCard & {
 export type ReviewContent = {
   title: string;
   category: Category;
-  author: string;
+  author_id: string;
+  author_email: string;
   created_at: string;
   content: string;
 };

--- a/src/entities/review/model/type.ts
+++ b/src/entities/review/model/type.ts
@@ -39,7 +39,8 @@ export type ReviewDetail = {
   board_id: number;
   title: string;
   category: Category;
-  author: string;
+  author_id: string;
+  author_email: string;
   created_at: string;
   content: string;
   bookmarks: number;

--- a/src/entities/review/model/type.ts
+++ b/src/entities/review/model/type.ts
@@ -5,7 +5,8 @@ export type Category = (typeof CATEGORY_LIST)[number]['value'];
 export type ReviewCard = {
   board_id: number;
   title: string;
-  author: string;
+  author_id: string;
+  author_email: string;
   category: Category;
   preview: string;
   comments_count: number;

--- a/src/entities/reviews/ui/CardDescription.tsx
+++ b/src/entities/reviews/ui/CardDescription.tsx
@@ -7,7 +7,7 @@ type Props = {
 };
 
 export default function CardDescription({
-  card: {category, image_url, title, preview, author, comments_count, bookmarks},
+  card: {category, image_url, title, preview, author_id, comments_count, bookmarks},
 }: Props) {
   return (
     <article className="h-full flex flex-col items-center justify-between font-semibold">
@@ -28,7 +28,7 @@ export default function CardDescription({
         </div>
       </div>
 
-      <p className="text-boldBlue text-sm">{author}</p>
+      <p className="text-boldBlue text-sm">{author_id}</p>
 
       <div className="flex mb-5 gap-5 text-xs font-normal">
         <div className="flex gap-1 items-center">

--- a/src/entities/reviews/ui/ReviewArticle.tsx
+++ b/src/entities/reviews/ui/ReviewArticle.tsx
@@ -7,7 +7,7 @@ type Props = {
 };
 
 export default function ReviewArticle({
-  searchReview: {author, board_id, bookmarks, category, comments_count, preview, created_at, image_url, title},
+  searchReview: {author_id, board_id, bookmarks, category, comments_count, preview, created_at, image_url, title},
 }: Props) {
   return (
     <article
@@ -20,7 +20,7 @@ export default function ReviewArticle({
           <p className="text-sm text-gray-500 mb-1">{created_at}</p>
           <div className="flex gap-3 text-sm text-gray-500">
             <p>{category}</p>
-            <p>{author}</p>
+            <p>{author_id}</p>
           </div>
         </article>
         <article className="px-4 md:px-0 text-sm line-clamp-2 md:line-clamp-3 mb-4 md:mb-7 md:flex-1 md:max-w-[400px] lg:max-w-[550px]">

--- a/src/entities/reviews/ui/ReviewsGrid.tsx
+++ b/src/entities/reviews/ui/ReviewsGrid.tsx
@@ -27,7 +27,7 @@ type Props =
   | {
       reviews: ReviewCard[];
       from: 'myBookmarkedReviews';
-      userId: string | null;
+      userEmail: string | null;
     };
 
 export default function ReviewsGrid(props: Props) {
@@ -39,7 +39,7 @@ export default function ReviewsGrid(props: Props) {
       case 'myReviews':
         return <MyPageReviewCard key={card.board_id} card={card} isAuthor={true} context="my" />;
       case 'myBookmarkedReviews':
-        const isAuthor = card.author === props.userId;
+        const isAuthor = card.author_email === props.userEmail;
         return <MyPageReviewCard key={card.board_id} card={card} isAuthor={isAuthor} context="bookmarks" />;
       case 'bestReviews':
         return <BestReviewCard key={card.board_id} card={card} />;

--- a/src/features/review/comments/ui/CommentCard.tsx
+++ b/src/features/review/comments/ui/CommentCard.tsx
@@ -8,8 +8,8 @@ type Props = {
 };
 
 export default function CommentCard({comment, userEmail, reviewId}: Props) {
-  const {author, content, created_at, profile_image} = comment;
-  const isAuthor = userEmail === author;
+  const {author_id, author_email, content, created_at, profile_image} = comment;
+  const isAuthor = userEmail === author_email;
 
   const {deleteReviewComment, isPending} = useDeleteReviewComment();
 
@@ -27,10 +27,10 @@ export default function CommentCard({comment, userEmail, reviewId}: Props) {
     <>
       <div className="flex min-h-[100px] gap-3 mx-2 px-3 pt-5 mb-5 bg-slate-100 rounded-lg relative">
         {isPending && <div className="z-10 absolute inset-0 bg-gray-300/50 rounded-lg animate-pulse" />}
-        <Avatar src={profile_image} alt={`${author}님의 프로필 이미지`} />
+        <Avatar src={profile_image} alt={`${author_id}님의 프로필 이미지`} />
         <article className="w-full flex flex-col">
           <div className="flex items-center gap-2 mb-1">
-            <span className="text-sm md:text-base font-semibold">{author.split('@')[0]}</span>
+            <span className="text-sm md:text-base font-semibold">{author_id}</span>
             <time className="text-xs md:text-sm text-gray-500" dateTime={created_at}>
               ({created_at})
             </time>

--- a/src/features/review/editor/lib/useSubmitReview.ts
+++ b/src/features/review/editor/lib/useSubmitReview.ts
@@ -45,7 +45,7 @@ function useSubmitReview({onPreview, onSave}: Props) {
 
     switch (type) {
       case 'preview':
-        return onPreview({...commonPayload, author: userId, created_at: '0000-00-00'});
+        return onPreview({...commonPayload, author_id: userId, author_email: userEmail, created_at: '0000-00-00'});
       case 'save':
         return onSave({...commonPayload, authorEmail: userEmail});
       default:

--- a/src/features/review/viewer/ui/Viewer.tsx
+++ b/src/features/review/viewer/ui/Viewer.tsx
@@ -1,7 +1,7 @@
 import {CATEGORY_MAP, ReviewContent} from '@/entities/review';
 import {Badge} from '@/shared/ui/components';
 
-export default function Viewer({title, category, author, created_at, content}: ReviewContent) {
+export default function Viewer({title, category, author_id, created_at, content}: ReviewContent) {
   return (
     <section className="flex flex-col w-full h-full min-h-[350px] md:min-h-[500px] overflow-auto">
       <header className="mx-4 mt-4 pb-4 border-b-2 border-gray-300">
@@ -10,7 +10,7 @@ export default function Viewer({title, category, author, created_at, content}: R
         <div className="flex items-center gap-2 ml-0.5 mt-2">
           <div className="flex items-center gap-2">
             <div className="w-[35px] h-[35px] bg-gray-400 rounded-full" />
-            <p>{author}</p>
+            <p>{author_id}</p>
           </div>
           <p className="text-gray-500">{created_at}</p>
         </div>

--- a/src/features/reviews/my/ui/MyBookmarkedReviews.tsx
+++ b/src/features/reviews/my/ui/MyBookmarkedReviews.tsx
@@ -1,7 +1,7 @@
 import Empty from './Empty';
 import Pagination from '@/widgets/pagination';
 import {ReviewsGrid, useMyBookmarkedReviews} from '@/entities/reviews';
-import {useUserId} from '@/entities/auth';
+import {useUserEmail} from '@/entities/auth';
 
 type Props = {
   currentPage: number;
@@ -9,7 +9,7 @@ type Props = {
 
 export default function MyBookmarkedReviews({currentPage}: Props) {
   const {results, total_pages} = useMyBookmarkedReviews(currentPage);
-  const userId = useUserId();
+  const userEmail = useUserEmail();
 
   if (results.length === 0) {
     return <Empty title="아직 저장한 후기가 없어요." linkText="후기 보러가기" linkHref="/search" />;
@@ -17,7 +17,7 @@ export default function MyBookmarkedReviews({currentPage}: Props) {
 
   return (
     <section>
-      <ReviewsGrid reviews={results} from="myBookmarkedReviews" userId={userId} />
+      <ReviewsGrid reviews={results} from="myBookmarkedReviews" userEmail={userEmail} />
       <Pagination
         currentPage={currentPage}
         totalPages={total_pages}

--- a/src/views/review/detail/ui/ReviewDetailPage.tsx
+++ b/src/views/review/detail/ui/ReviewDetailPage.tsx
@@ -1,9 +1,9 @@
+import Link from 'next/link';
 import ReviewDetailInteractive from './ReviewDetailInteractive';
 import {Viewer} from '@/features/review/viewer';
 import {DeleteButton} from '@/entities/reviews';
 import {getReviewDetail} from '@/entities/review';
 import getSessionUserEmail from '@/shared/lib/utils/getSessionUserEmail';
-import Link from 'next/link';
 
 type Props = {
   params: Promise<{reviewId: string}>;
@@ -13,10 +13,10 @@ export default async function ReviewDetailPage({params}: Props) {
   const {reviewId} = await params;
   const parsedReviewId = Number(reviewId);
 
-  const {author, content, category, created_at, title} = await getReviewDetail(parsedReviewId);
+  const {author_id, author_email, content, category, created_at, title} = await getReviewDetail(parsedReviewId);
 
   const sessionUserEmail = await getSessionUserEmail();
-  const isAuthor = sessionUserEmail === author;
+  const isAuthor = sessionUserEmail === author_email;
 
   return (
     <section className="flex flex-col w-full max-w-5xl mx-auto items-center relative">
@@ -28,7 +28,14 @@ export default async function ReviewDetailPage({params}: Props) {
           <DeleteButton category={category} reviewId={parsedReviewId} />
         </div>
       )}
-      <Viewer title={title} author={author} content={content} category={category} created_at={created_at} />
+      <Viewer
+        title={title}
+        author_id={author_id}
+        author_email={author_email}
+        content={content}
+        category={category}
+        created_at={created_at}
+      />
       <ReviewDetailInteractive reviewId={parsedReviewId} category={category} />
     </section>
   );

--- a/src/views/review/edit/ui/EditReview.tsx
+++ b/src/views/review/edit/ui/EditReview.tsx
@@ -1,5 +1,5 @@
-import {getReviewDetail} from '@/entities/review';
 import EditReviewClient from './EditReviewClient';
+import {getReviewDetail} from '@/entities/review';
 
 type Props = {
   reviewId: number;
@@ -9,7 +9,7 @@ type Props = {
 export default async function EditReview({reviewId, sessionUserEmail}: Props) {
   const data = await getReviewDetail(reviewId);
 
-  if (data.author !== sessionUserEmail) {
+  if (data.author_email !== sessionUserEmail) {
     throw new Error('작성자만 리뷰를 수정할 수 있습니다.');
   }
 


### PR DESCRIPTION
## 📝 요약(Summary)

- API 명세 변경으로 모든 응답 데이터의 `author` 필드를 `author_id`, `author_email`로 세분화.
- 모든 작성자 판단 및 로그인 사용자 판단에 `author_email` 속성을 사용하도록 변경.

## 🛠️ PR 유형

- [X] 코드 리팩토링