### PR TITLE
Feat(메인페이지) - Hero 컴포넌트의 게시글 작성 페이지 이동 버튼 클릭 시 로그인 상태에 따라 조건부 라우팅

### DIFF
--- a/src/widgets/hero/ui/Hero.tsx
+++ b/src/widgets/hero/ui/Hero.tsx
@@ -1,6 +1,5 @@
-import Link from 'next/link';
+import WriteReviewButton from './WriteReviewButton';
 import {SearchBar} from '@/features/reviews/search-bar';
-import {Button} from '@/shared/shadcnComponent/ui/button';
 
 export default function Hero() {
   return (
@@ -15,11 +14,7 @@ export default function Hero() {
           바로 여기 <span className="text-boldBlue">{"'모두의 : 후기'"}</span>에서 확인하세요.
         </p>
       </article>
-      <Link className="mb-10" href="/reviews/new" scroll={false}>
-        <Button className=" bg-boldBlue rounded-3xl hover:bg-extraboldBlue p-5 text-[14px] md:text-[16px] md:p-6 lg:text-[18px]">
-          {'내 경험 공유하기>'}
-        </Button>
-      </Link>
+      <WriteReviewButton />
       <SearchBar />
     </section>
   );

--- a/src/widgets/hero/ui/WriteReviewButton.tsx
+++ b/src/widgets/hero/ui/WriteReviewButton.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import {useRouter} from 'next/navigation';
+import {useIsLoggedIn} from '@/entities/auth';
+import {Button} from '@/shared/shadcnComponent/ui/button';
+import {LoginModal, Modal, useModal} from '@/shared/ui/modal';
+
+export default function WriteReviewButton() {
+  const router = useRouter();
+
+  const isLoggedIn = useIsLoggedIn();
+  const {openModal, handleModalOpen, handleModalClose} = useModal();
+
+  const handleClick = () => {
+    if (!isLoggedIn) {
+      handleModalOpen();
+      return;
+    }
+
+    router.push('/reviews/new', {scroll: false});
+  };
+
+  return (
+    <>
+      <Button
+        className=" bg-boldBlue rounded-3xl hover:bg-extraboldBlue p-5 text-[14px] md:text-[16px] md:p-6 lg:text-[18px] mb-10"
+        onClick={handleClick}
+      >
+        {'내 경험 공유하기>'}
+      </Button>
+      {openModal && (
+        <Modal onClose={handleModalClose}>
+          <LoginModal onClose={handleModalClose} />
+        </Modal>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
## 📝 요약(Summary)

- 메인 페이지 Hero 컴포넌트의 '내 경험 공유하기' 버튼 클릭 시 로그인 사용자가 아닐 경우 로그인 모달 표시.
- 로그인 사용자일 경우 게시글 작성 페이지로 라우팅.

### `src/widgets/hero/ui/WriteReviewButton.tsx`
- `useIsLoggedIn` 훅을 호출해 로그인 상태를 `isLoggedIn` 상수에 할당.
- '내 경험 공유하기' 버튼 클릭 시 `handleClick` 함수 실행.
- 로그인 사용자가 아닐 경우 로그인 모달 표시를 위해 `handleModalOpen` 함수 실행 후 종료.
- 로그인 사용자일 경우 게시글 작성 페이지로 라우팅.

### `src/widgets/hero/ui/Hero.tsx`
- 기존 '내 경험 공유하기' 버튼 영역을 `WriteReviewButton` 컴포넌트로 대체.
- `Hero` 컴포넌트 자체는 서버 컴포넌트로 실행하며, 게시글 작성 페이지 이동 버튼만 별도의 클라이언트 컴포넌트로 분리.

## 🛠️ PR 유형

- [X] 새로운 기능 추가

## 📸스크린샷

<div align="center">

| 비 로그인 사용자 플로우 |
| -- |
| <img src="https://github.com/user-attachments/assets/d0278333-470e-4765-b387-7afa7f0f0c54" width="600px" /> |

</div>
