### PR TITLE
Feat(게시글 모음 페이지) - 화면 우측 하단 영역에 게시글 작성 플로팅 버튼 표시

### DIFF
--- a/src/views/search/ui/CategorySearchPage.tsx
+++ b/src/views/search/ui/CategorySearchPage.tsx
@@ -1,10 +1,12 @@
 import {CategoryReviews} from '@/features/reviews/category';
+import FloatingWriteButton from './FloatingWriteButton';
 
 export default function CategorySearchPage() {
   return (
     <section className="flex flex-col md:px-8 max-w-5xl mx-auto">
       <h4 className="font-bold text-2xl mt-3 mb-4 md:mb-6 md:text-3xl px-5"> 후기글 모음 </h4>
       <CategoryReviews />
+      <FloatingWriteButton />
     </section>
   );
 }

--- a/src/views/search/ui/FloatingWriteButton.tsx
+++ b/src/views/search/ui/FloatingWriteButton.tsx
@@ -1,9 +1,39 @@
+'use client';
+
+import {useRouter} from 'next/navigation';
+import {useIsLoggedIn} from '@/entities/auth';
 import {LucideIcon} from '@/shared/ui/icons';
+import {LoginModal, Modal, useModal} from '@/shared/ui/modal';
 
 export default function FloatingWriteButton() {
+  const router = useRouter();
+
+  const isLoggedIn = useIsLoggedIn();
+  const {openModal, handleModalOpen, handleModalClose} = useModal();
+
+  const handleClick = () => {
+    if (!isLoggedIn) {
+      handleModalOpen();
+      return;
+    }
+
+    router.push('/reviews/new', {scroll: false});
+  };
+
   return (
-    <button className="fixed bottom-4 right-4 md:bottom-8 md:right-6 lg:right-8 bg-boldBlue text-white rounded-full p-3 shadow-lg hover:bg-extraboldBlue transition-colors">
-      <LucideIcon name="Plus" size={24} />
-    </button>
+    <>
+      <button
+        className="fixed bottom-4 right-4 md:bottom-8 md:right-6 lg:right-8 bg-boldBlue text-white rounded-full p-3 shadow-lg hover:bg-extraboldBlue transition-colors"
+        onClick={handleClick}
+        aria-label="리뷰 작성하기"
+      >
+        <LucideIcon name="Plus" size={24} />
+      </button>
+      {openModal && (
+        <Modal onClose={handleModalClose}>
+          <LoginModal onClose={handleModalClose} />
+        </Modal>
+      )}
+    </>
   );
 }

--- a/src/views/search/ui/FloatingWriteButton.tsx
+++ b/src/views/search/ui/FloatingWriteButton.tsx
@@ -2,7 +2,7 @@ import {LucideIcon} from '@/shared/ui/icons';
 
 export default function FloatingWriteButton() {
   return (
-    <button>
+    <button className="fixed bottom-4 right-4 md:bottom-8 md:right-6 lg:right-8 bg-boldBlue text-white rounded-full p-3 shadow-lg hover:bg-extraboldBlue transition-colors">
       <LucideIcon name="Plus" size={24} />
     </button>
   );

--- a/src/views/search/ui/FloatingWriteButton.tsx
+++ b/src/views/search/ui/FloatingWriteButton.tsx
@@ -1,0 +1,9 @@
+import {LucideIcon} from '@/shared/ui/icons';
+
+export default function FloatingWriteButton() {
+  return (
+    <button>
+      <LucideIcon name="Plus" size={24} />
+    </button>
+  );
+}

--- a/src/views/search/ui/KeywordSearchPage.tsx
+++ b/src/views/search/ui/KeywordSearchPage.tsx
@@ -1,5 +1,6 @@
 import {KeywordReviews} from '@/features/reviews/keyword';
 import {SearchBar} from '@/features/reviews/search-bar';
+import FloatingWriteButton from './FloatingWriteButton';
 
 type Props = {
   params: Promise<{keyword: string}>;
@@ -15,6 +16,7 @@ export default async function KeywordSearchPage({params}: Props) {
       <h2 className="font-bold text-2xl mt-3 mb-6 md:mb-8 md:text-3xl px-5">{decodedQuery} 검색 결과</h2>
       <SearchBar />
       <KeywordReviews />
+      <FloatingWriteButton />
     </section>
   );
 }


### PR DESCRIPTION
## 📝 요약(Summary)

- 게시글 모음 페이지(카테고리, 키워드) 우측 하단 영역에 게시글 작성 플로팅 버튼 표시.
- 로그인 상태에 따라 모달 표시(비 로그인 사용자) 혹은 게시글 작성 페이지로 라우팅(로그인 사용자).

### `src/views/search/ui/FloatingWriteButton.tsx`
- `fixed` 요소로 화면 우측 하단 영역에 항상 표시되도록 설정.
- `useIsLoggedIn` 훅을 호출해 로그인 상태를 `isLoggedIn` 상수에 할당.
- '+' 버튼 클릭 시 `handleClick` 함수 실행.
- 로그인 사용자가 아닐 경우 로그인 모달 표시를 위해 `handleModalOpen` 함수 실행 후 종료.
- 로그인 사용자일 경우 게시글 작성 페이지로 라우팅.

## 🛠️ PR 유형

- [X] 새로운 기능 추가

## 📸스크린샷

<div align="center">

| 플로팅 버튼 UI |
| -- |
| <img src="https://github.com/user-attachments/assets/1cebfd2e-b698-43b3-8979-3f90c773e1a9" width="600px" /> |

| 비 로그인 사용자 |
|-- |
| <img src="https://github.com/user-attachments/assets/a7c0b070-4dd6-424f-997a-4abbf7a1acac" width="600px" /> |

| 로그인 사용자 |
|-- |
| <img src="https://github.com/user-attachments/assets/a3fdff24-754f-4abd-9d45-3a64c0a4d301" width="600px" /> |

</div>