### PR TITLE
Feat/side bar

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.0.1",
+    "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-label": "^2.1.3",
     "@radix-ui/react-popover": "^1.1.7",
     "@radix-ui/react-select": "^2.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@hookform/resolvers':
         specifier: ^5.0.1
         version: 5.1.1(react-hook-form@7.58.0(react@19.0.0))
+      '@radix-ui/react-dialog':
+        specifier: ^1.1.14
+        version: 1.1.14(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@radix-ui/react-label':
         specifier: ^2.1.3
         version: 2.1.7(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -491,6 +494,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-dialog@1.1.14':
+    resolution: {integrity: sha512-+CpweKjqpzTmwRwcYECQcNYbI8V9VSQt0SNFKeEBLgfucbsLssU6Ppq7wUdNXEGb573bMjFhVjKVll8rmV6zMw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-direction@1.1.1':
@@ -2877,6 +2893,28 @@ snapshots:
       react: 19.0.0
     optionalDependencies:
       '@types/react': 19.0.8
+
+  '@radix-ui/react-dialog@1.1.14(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.2
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.0.8)(react@19.0.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.0.8)(react@19.0.0)
+      '@radix-ui/react-dismissable-layer': 1.1.10(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-focus-guards': 1.1.2(@types/react@19.0.8)(react@19.0.0)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.0.8)(react@19.0.0)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-presence': 1.1.4(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.0.8)(react@19.0.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.0.8)(react@19.0.0)
+      aria-hidden: 1.2.4
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+      react-remove-scroll: 2.6.3(@types/react@19.0.8)(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.8
+      '@types/react-dom': 19.0.3(@types/react@19.0.8)
 
   '@radix-ui/react-direction@1.1.1(@types/react@19.0.8)(react@19.0.0)':
     dependencies:

--- a/src/shared/shadcnComponent/ui/sheet.tsx
+++ b/src/shared/shadcnComponent/ui/sheet.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import * as React from 'react';
+import * as SheetPrimitive from '@radix-ui/react-dialog';
+import {cva, type VariantProps} from 'class-variance-authority';
+import {X} from 'lucide-react';
+
+import {cn} from '@/shared/lib/utils/cn';
+
+const Sheet = SheetPrimitive.Root;
+
+const SheetTrigger = SheetPrimitive.Trigger;
+
+const SheetClose = SheetPrimitive.Close;
+
+const SheetPortal = SheetPrimitive.Portal;
+
+const SheetOverlay = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Overlay>
+>(({className, ...props}, ref) => (
+  <SheetPrimitive.Overlay
+    className={cn(
+      'fixed inset-0 z-50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      className,
+    )}
+    {...props}
+    ref={ref}
+  />
+));
+SheetOverlay.displayName = SheetPrimitive.Overlay.displayName;
+
+const sheetVariants = cva(
+  'fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500 data-[state=open]:animate-in data-[state=closed]:animate-out',
+  {
+    variants: {
+      side: {
+        top: 'inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top',
+        bottom:
+          'inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom',
+        left: 'inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm',
+        right:
+          'inset-y-0 right-0 h-full w-3/4 border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm',
+      },
+    },
+    defaultVariants: {
+      side: 'right',
+    },
+  },
+);
+
+interface SheetContentProps
+  extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
+    VariantProps<typeof sheetVariants> {}
+
+const SheetContent = React.forwardRef<React.ElementRef<typeof SheetPrimitive.Content>, SheetContentProps>(
+  ({side = 'right', className, children, ...props}, ref) => (
+    <SheetPortal>
+      <SheetOverlay />
+      <SheetPrimitive.Content ref={ref} className={cn(sheetVariants({side}), className)} {...props}>
+        <SheetPrimitive.Close className="absolute right-4 top-7 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none disabled:pointer-events-none data-[state=open]:bg-secondary">
+          <X className="h-5 w-5" />
+          <span className="sr-only">Close</span>
+        </SheetPrimitive.Close>
+        {children}
+      </SheetPrimitive.Content>
+    </SheetPortal>
+  ),
+);
+SheetContent.displayName = SheetPrimitive.Content.displayName;
+
+const SheetHeader = ({className, ...props}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('flex flex-col text-left space-y-1.5', className)} {...props} />
+);
+SheetHeader.displayName = 'SheetHeader';
+
+const SheetFooter = ({className, ...props}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('flex flex-col-reverse sm:flex-row sm:space-x-2', className)} {...props} />
+);
+SheetFooter.displayName = 'SheetFooter';
+
+const SheetTitle = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Title>
+>(({className, ...props}, ref) => (
+  <SheetPrimitive.Title ref={ref} className={cn('text-lg font-semibold text-foreground', className)} {...props} />
+));
+SheetTitle.displayName = SheetPrimitive.Title.displayName;
+
+const SheetDescription = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Description>
+>(({className, ...props}, ref) => (
+  <SheetPrimitive.Description ref={ref} className={cn('text-sm text-muted-foreground', className)} {...props} />
+));
+SheetDescription.displayName = SheetPrimitive.Description.displayName;
+
+export {
+  Sheet,
+  SheetPortal,
+  SheetOverlay,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetFooter,
+  SheetTitle,
+  SheetDescription,
+};

--- a/src/shared/ui/components/Avatar.tsx
+++ b/src/shared/ui/components/Avatar.tsx
@@ -7,7 +7,7 @@ type Props = {
 
 export default function Avatar({src, alt}: Props) {
   return (
-    <div className="rounded-full flex justify-center items-center min-w-10 h-10 md:min-w-11 md:h-11 bg-gray-300">
+    <div className="rounded-full flex justify-center items-center min-w-10 h-10 md:min-w-11 md:h-11 bg-boldBlue">
       <Image
         className="rounded-full bg-white object-cover w-9 h-9 md:w-10 md:h-10"
         src={src}

--- a/src/views/mypage/ui/MyPage.tsx
+++ b/src/views/mypage/ui/MyPage.tsx
@@ -1,7 +1,8 @@
-import checkSession from '@/shared/lib/utils/checkSession';
+import Link from 'next/link';
 import UserInfo from './UserInfo';
 import ReviewTabs from './ReviewTabs';
-import Link from 'next/link';
+import {Sidebar} from '@/widgets/side-bar';
+import checkSession from '@/shared/lib/utils/checkSession';
 import {LucideIcon} from '@/shared/ui/icons';
 
 export default async function MyPage() {
@@ -11,11 +12,14 @@ export default async function MyPage() {
     <section className="fixed inset-0 w-full h-full bg-white overflow-auto">
       <section className="w-full max-w-5xl mx-auto mb-4 md:mb-8">
         <section className="bg-lightBlue p-4 flex flex-col justify-between mb-[90px] md:mb-[110px]">
-          <header className="flex items-center gap-2 mt-2 px-2">
-            <Link href="/" aria-label="메인 페이지로 이동">
-              <LucideIcon name="House" className="w-7 h-7 text-boldBlue hover:scale-110 transition-transform" />
-            </Link>
-            <h2 className="text-2xl text-boldBlue font-bold">마이페이지</h2>
+          <header className="flex items-center justify-between mt-2 px-2 md:px-4">
+            <div className="flex items-center gap-2">
+              <Link href="/" aria-label="메인 페이지로 이동">
+                <LucideIcon name="House" className="w-7 h-7 text-boldBlue hover:scale-110 transition-transform" />
+              </Link>
+              <h2 className="text-2xl text-boldBlue font-bold">마이페이지</h2>
+            </div>
+            <Sidebar />
           </header>
           <UserInfo />
         </section>

--- a/src/widgets/header/ui/Header.tsx
+++ b/src/widgets/header/ui/Header.tsx
@@ -1,4 +1,4 @@
-import {Button} from '@/shared/shadcnComponent/ui/button';
+import {Sidebar} from '@/widgets/side-bar';
 import {cookies} from 'next/headers';
 import Link from 'next/link';
 
@@ -6,30 +6,13 @@ export default async function Header() {
   const cookieStore = await cookies();
 
   const isLoggedIn = cookieStore.has('refreshToken');
-  const LOGIN_URL = process.env.NEXT_PUBLIC_LOGIN_URL;
-
-  if (!LOGIN_URL) {
-    throw new Error('로그인 URL이 환경변수에 정의되지 않았습니다.');
-  }
 
   return (
     <header className="flex justify-between items-center py-5 px-6 md:px-8 lg:py-6 lg:px-10">
       <Link href="/">
         <h2 className="text-2xl md:text-3xl font-bold text-boldBlue">모두의 : 후기</h2>
       </Link>
-      {isLoggedIn ? (
-        <Link href={'/mypage'} scroll={false}>
-          <Button variant="logInOut" size="logInOut">
-            마이페이지
-          </Button>
-        </Link>
-      ) : (
-        <Link href={`${process.env.NEXT_PUBLIC_API_URL}/oauth2/authorization/kakao`}>
-          <Button variant="logInOut" size="logInOut">
-            로그인
-          </Button>
-        </Link>
-      )}
+      <Sidebar />
     </header>
   );
 }

--- a/src/widgets/header/ui/Header.tsx
+++ b/src/widgets/header/ui/Header.tsx
@@ -1,12 +1,7 @@
-import {Sidebar} from '@/widgets/side-bar';
-import {cookies} from 'next/headers';
 import Link from 'next/link';
+import {Sidebar} from '@/widgets/side-bar';
 
-export default async function Header() {
-  const cookieStore = await cookies();
-
-  const isLoggedIn = cookieStore.has('refreshToken');
-
+export default function Header() {
   return (
     <header className="flex justify-between items-center py-5 px-6 md:px-8 lg:py-6 lg:px-10">
       <Link href="/">

--- a/src/widgets/side-bar/index.ts
+++ b/src/widgets/side-bar/index.ts
@@ -1,0 +1,1 @@
+export {default as Sidebar} from './ui/Sidebar';

--- a/src/widgets/side-bar/ui/LoginRequiredPopover.tsx
+++ b/src/widgets/side-bar/ui/LoginRequiredPopover.tsx
@@ -1,0 +1,32 @@
+import Link from 'next/link';
+import {Popover, PopoverContent, PopoverTrigger} from '@/shared/shadcnComponent/ui/popover';
+import {LucideIcon} from '@/shared/ui/icons';
+
+type Props = {
+  title: string;
+};
+
+export default function LoginRequiredPopover({title}: Props) {
+  const LOGIN_URL = process.env.NEXT_PUBLIC_LOGIN_URL;
+
+  if (!LOGIN_URL) {
+    throw new Error('로그인 URL이 환경변수에 정의되지 않았습니다.');
+  }
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button>
+          <LucideIcon name="LockKeyhole" size={20} /> <span>{title}</span>
+        </button>
+      </PopoverTrigger>
+      <PopoverContent>
+        <div>
+          <h3>로그인 후 이용할 수 있어요.</h3>
+          <p>로그인하면 더 많은 기능을 이용할 수 있어요.</p>
+          <Link href={LOGIN_URL}>로그인하기</Link>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/widgets/side-bar/ui/LoginRequiredPopover.tsx
+++ b/src/widgets/side-bar/ui/LoginRequiredPopover.tsx
@@ -16,15 +16,20 @@ export default function LoginRequiredPopover({title}: Props) {
   return (
     <Popover>
       <PopoverTrigger asChild>
-        <button>
+        <button className="flex items-center text-muted-foreground gap-1 hover:text-boldBlue transition-colors">
           <LucideIcon name="LockKeyhole" size={20} /> <span>{title}</span>
         </button>
       </PopoverTrigger>
       <PopoverContent>
-        <div>
-          <h3>로그인 후 이용할 수 있어요.</h3>
-          <p>로그인하면 더 많은 기능을 이용할 수 있어요.</p>
-          <Link href={LOGIN_URL}>로그인하기</Link>
+        <div className="flex flex-col">
+          <h3 className="font-semibold mb-2">로그인 후 이용할 수 있어요.</h3>
+          <p className="text-sm text-muted-foreground mb-1">로그인하면 더 많은 기능을 이용할 수 있어요.</p>
+          <Link
+            href={LOGIN_URL}
+            className="w-full text-center text-sm bg-boldBlue text-white py-1.5 font-semibold rounded-md hover:bg-extraboldBlue transition-colors"
+          >
+            로그인하기
+          </Link>
         </div>
       </PopoverContent>
     </Popover>

--- a/src/widgets/side-bar/ui/Sidebar.tsx
+++ b/src/widgets/side-bar/ui/Sidebar.tsx
@@ -1,3 +1,48 @@
+const SIDEBAR_ROUTES = [
+  {
+    title: '홈',
+    href: '/',
+    isActive: (path: string) => path === '/',
+    requiresAuth: false,
+  },
+  {
+    title: '마이페이지',
+    href: '/mypage',
+    isActive: (path: string) => path === '/mypage',
+    requiresAuth: true,
+  },
+  {
+    title: '후기 작성하기',
+    href: '/reviews/new',
+    isActive: (path: string) => path === '/reviews/new',
+    requiresAuth: true,
+  },
+  {
+    title: '후기 둘러보기',
+    href: '/search',
+    isActive: (path: string) => path === '/search',
+    requiresAuth: false,
+  },
+  {
+    title: '내가 작성한 후기',
+    href: '/mypage?tabs=my',
+    isActive: (path: string) => path === '/mypage?tabs=my',
+    requiresAuth: true,
+  },
+  {
+    title: '내가 저장한 후기',
+    href: '/mypage?tabs=myBookmarks',
+    isActive: (path: string) => path === '/mypage?tabs=myBookmarks',
+    requiresAuth: true,
+  },
+  {
+    title: '문의하기',
+    href: '/feedback',
+    isActive: (path: string) => path === '/feedback',
+    requiresAuth: false,
+  },
+];
+
 export default function Sidebar() {
-    return  
+  return;
 }

--- a/src/widgets/side-bar/ui/Sidebar.tsx
+++ b/src/widgets/side-bar/ui/Sidebar.tsx
@@ -10,6 +10,7 @@ import {
   SheetTrigger,
 } from '@/shared/shadcnComponent/ui/sheet';
 import {LucideIcon} from '@/shared/ui/icons';
+import LoginRequiredPopover from './LoginRequiredPopover';
 
 const SIDEBAR_ROUTES = [
   {
@@ -78,13 +79,17 @@ export default function Sidebar({isLoggedIn}: Props) {
           <SheetDescription>세상의 모든 후기를 확인해보세요.</SheetDescription>
         </SheetHeader>
         <nav>
-          {SIDEBAR_ROUTES.map(({title, href, isActive, requiresAuth}) => (
-            <SheetClose key={title} asChild>
-              <Link key={title} href={href}>
-                <span>{title}</span>
-              </Link>
-            </SheetClose>
-          ))}
+          {SIDEBAR_ROUTES.map(({title, href, isActive, requiresAuth}) =>
+            !requiresAuth || isLoggedIn ? (
+              <SheetClose key={title} asChild>
+                <Link key={title} href={href}>
+                  <span>{title}</span>
+                </Link>
+              </SheetClose>
+            ) : (
+              <LoginRequiredPopover key={title} title={title} />
+            ),
+          )}
         </nav>
         <SheetFooter>
           {isLoggedIn ? <div>{/* TODO: 로그인 사용자 정보 표시 */}</div> : <Link href={LOGIN_URL}>로그인</Link>}

--- a/src/widgets/side-bar/ui/Sidebar.tsx
+++ b/src/widgets/side-bar/ui/Sidebar.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import {usePathname} from 'next/navigation';
 import UserInfo from './UserInfo';
 import LoginRequiredPopover from './LoginRequiredPopover';
+import {useIsLoggedIn} from '@/entities/auth';
 import {
   Sheet,
   SheetClose,
@@ -61,12 +62,10 @@ const SIDEBAR_ROUTES = [
   },
 ];
 
-type Props = {
-  isLoggedIn: boolean;
-};
-
-export default function Sidebar({isLoggedIn}: Props) {
+export default function Sidebar() {
   const pathName = usePathname();
+  const isLoggedIn = useIsLoggedIn();
+
   const LOGIN_URL = process.env.NEXT_PUBLIC_LOGIN_URL;
 
   if (!LOGIN_URL) {

--- a/src/widgets/side-bar/ui/Sidebar.tsx
+++ b/src/widgets/side-bar/ui/Sidebar.tsx
@@ -1,14 +1,15 @@
+import Link from 'next/link';
 import {
   Sheet,
   SheetClose,
   SheetContent,
   SheetDescription,
+  SheetFooter,
   SheetHeader,
   SheetTitle,
   SheetTrigger,
 } from '@/shared/shadcnComponent/ui/sheet';
 import {LucideIcon} from '@/shared/ui/icons';
-import Link from 'next/link';
 
 const SIDEBAR_ROUTES = [
   {
@@ -55,7 +56,17 @@ const SIDEBAR_ROUTES = [
   },
 ];
 
-export default function Sidebar() {
+type Props = {
+  isLoggedIn: boolean;
+};
+
+export default function Sidebar({isLoggedIn}: Props) {
+  const LOGIN_URL = process.env.NEXT_PUBLIC_LOGIN_URL;
+
+  if (!LOGIN_URL) {
+    throw new Error('로그인 URL이 환경변수에 정의되지 않았습니다.');
+  }
+
   return (
     <Sheet>
       <SheetTrigger>
@@ -75,6 +86,9 @@ export default function Sidebar() {
             </SheetClose>
           ))}
         </nav>
+        <SheetFooter>
+          {isLoggedIn ? <div>{/* TODO: 로그인 사용자 정보 표시 */}</div> : <Link href={LOGIN_URL}>로그인</Link>}
+        </SheetFooter>
       </SheetContent>
     </Sheet>
   );

--- a/src/widgets/side-bar/ui/Sidebar.tsx
+++ b/src/widgets/side-bar/ui/Sidebar.tsx
@@ -1,0 +1,3 @@
+export default function Sidebar() {
+    return  
+}

--- a/src/widgets/side-bar/ui/Sidebar.tsx
+++ b/src/widgets/side-bar/ui/Sidebar.tsx
@@ -11,6 +11,7 @@ import {
 } from '@/shared/shadcnComponent/ui/sheet';
 import {LucideIcon} from '@/shared/ui/icons';
 import LoginRequiredPopover from './LoginRequiredPopover';
+import UserInfo from './UserInfo';
 
 const SIDEBAR_ROUTES = [
   {
@@ -91,9 +92,7 @@ export default function Sidebar({isLoggedIn}: Props) {
             ),
           )}
         </nav>
-        <SheetFooter>
-          {isLoggedIn ? <div>{/* TODO: 로그인 사용자 정보 표시 */}</div> : <Link href={LOGIN_URL}>로그인</Link>}
-        </SheetFooter>
+        <SheetFooter>{isLoggedIn ? <UserInfo /> : <Link href={LOGIN_URL}>로그인</Link>}</SheetFooter>
       </SheetContent>
     </Sheet>
   );

--- a/src/widgets/side-bar/ui/Sidebar.tsx
+++ b/src/widgets/side-bar/ui/Sidebar.tsx
@@ -1,4 +1,9 @@
+'use client';
+
 import Link from 'next/link';
+import {usePathname} from 'next/navigation';
+import UserInfo from './UserInfo';
+import LoginRequiredPopover from './LoginRequiredPopover';
 import {
   Sheet,
   SheetClose,
@@ -10,8 +15,6 @@ import {
   SheetTrigger,
 } from '@/shared/shadcnComponent/ui/sheet';
 import {LucideIcon} from '@/shared/ui/icons';
-import LoginRequiredPopover from './LoginRequiredPopover';
-import UserInfo from './UserInfo';
 
 const SIDEBAR_ROUTES = [
   {
@@ -63,6 +66,7 @@ type Props = {
 };
 
 export default function Sidebar({isLoggedIn}: Props) {
+  const pathName = usePathname();
   const LOGIN_URL = process.env.NEXT_PUBLIC_LOGIN_URL;
 
   if (!LOGIN_URL) {
@@ -72,18 +76,26 @@ export default function Sidebar({isLoggedIn}: Props) {
   return (
     <Sheet>
       <SheetTrigger>
-        <LucideIcon name="Menu" />
+        <LucideIcon name="Menu" className="hover:text-boldBlue md:hover:scale-105 transition-all" />
       </SheetTrigger>
-      <SheetContent>
-        <SheetHeader>
-          <SheetTitle>모두의 후기</SheetTitle>
+      <SheetContent className="w-[300px] flex flex-col">
+        <SheetHeader className="border-b-[3px] border-boldBlue pb-3">
+          <SheetTitle className="text-xl md:text-2xl mb-1">모두의 후기</SheetTitle>
           <SheetDescription>세상의 모든 후기를 확인해보세요.</SheetDescription>
         </SheetHeader>
-        <nav>
+        <nav className="flex-1 flex flex-col space-y-11 text-lg mt-5">
           {SIDEBAR_ROUTES.map(({title, href, isActive, requiresAuth}) =>
             !requiresAuth || isLoggedIn ? (
               <SheetClose key={title} asChild>
-                <Link key={title} href={href}>
+                <Link
+                  key={title}
+                  href={href}
+                  className={
+                    isActive(pathName)
+                      ? 'text-boldBlue font-semibold'
+                      : 'text-muted-foreground hover:text-boldBlue transition-colors'
+                  }
+                >
                   <span>{title}</span>
                 </Link>
               </SheetClose>
@@ -92,7 +104,18 @@ export default function Sidebar({isLoggedIn}: Props) {
             ),
           )}
         </nav>
-        <SheetFooter>{isLoggedIn ? <UserInfo /> : <Link href={LOGIN_URL}>로그인</Link>}</SheetFooter>
+        <SheetFooter>
+          {isLoggedIn ? (
+            <UserInfo />
+          ) : (
+            <Link
+              href={LOGIN_URL}
+              className="w-full text-center bg-boldBlue text-white py-1.5 font-semibold rounded-md hover:bg-extraboldBlue transition-colors mb-3"
+            >
+              로그인
+            </Link>
+          )}
+        </SheetFooter>
       </SheetContent>
     </Sheet>
   );

--- a/src/widgets/side-bar/ui/Sidebar.tsx
+++ b/src/widgets/side-bar/ui/Sidebar.tsx
@@ -1,3 +1,15 @@
+import {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from '@/shared/shadcnComponent/ui/sheet';
+import {LucideIcon} from '@/shared/ui/icons';
+import Link from 'next/link';
+
 const SIDEBAR_ROUTES = [
   {
     title: '홈',
@@ -44,5 +56,26 @@ const SIDEBAR_ROUTES = [
 ];
 
 export default function Sidebar() {
-  return;
+  return (
+    <Sheet>
+      <SheetTrigger>
+        <LucideIcon name="Menu" />
+      </SheetTrigger>
+      <SheetContent>
+        <SheetHeader>
+          <SheetTitle>모두의 후기</SheetTitle>
+          <SheetDescription>세상의 모든 후기를 확인해보세요.</SheetDescription>
+        </SheetHeader>
+        <nav>
+          {SIDEBAR_ROUTES.map(({title, href, isActive, requiresAuth}) => (
+            <SheetClose key={title} asChild>
+              <Link key={title} href={href}>
+                <span>{title}</span>
+              </Link>
+            </SheetClose>
+          ))}
+        </nav>
+      </SheetContent>
+    </Sheet>
+  );
 }

--- a/src/widgets/side-bar/ui/UserInfo.tsx
+++ b/src/widgets/side-bar/ui/UserInfo.tsx
@@ -6,11 +6,11 @@ export default function UserInfo() {
   const userEmail = useUserEmail();
 
   return (
-    <div>
+    <div className="flex items-center gap-2">
       <Avatar src="https://picsum.photos/200/200" alt={`${userId} 프로필 사진`} />
-      <div>
-        <span>{userId}</span>
-        <span>{userEmail}</span>
+      <div className="flex flex-col">
+        <span className="text-sm font-semibold">{userId}</span>
+        <span className="text-xs text-muted-foreground">{userEmail}</span>
       </div>
     </div>
   );

--- a/src/widgets/side-bar/ui/UserInfo.tsx
+++ b/src/widgets/side-bar/ui/UserInfo.tsx
@@ -1,0 +1,17 @@
+import {useUserEmail, useUserId} from '@/entities/auth';
+import {Avatar} from '@/shared/ui/components';
+
+export default function UserInfo() {
+  const userId = useUserId();
+  const userEmail = useUserEmail();
+
+  return (
+    <div>
+      <Avatar src="https://picsum.photos/200/200" alt={`${userId} 프로필 사진`} />
+      <div>
+        <span>{userId}</span>
+        <span>{userEmail}</span>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 📝 요약(Summary)

- 웹사이트 사용 중 페이지 간 이동의 불편함을 해결하기 위해 사이드바 네비게이션 구현.

### 문제점
서버에 올라간 후 직접 사이트를 이용해보면서 문제를 발견했는데요. 우리 사이트의 기존 헤더는 제한적인 네비게이션만 제공했습니다.
- 로그인 사용자: 마이페이지 버튼만 표시.
- 비로그인 사용자: 로그인 버튼만 표시.
- 메인페이지에서 페이지 하단 끝까지 스크롤 후 '더 많은 후기보기' 버튼을 클릭하지 않는다면, 사용자는 검색하기 페이지의 존재를 모를 수도 있겠다는 문제점을 발견했습니다.
- 또, 우리 사이트에서 지원하는 모든 기능을 제대로 표시하지 못할 수 있다는 문제점도 발견했습니다.

### 해결방안
**shadcn/ui**의 `Sheet` 컴포넌트 기반의 사이드바를 구현해 우리 사이트의 모든 주요 페이지로 빠르게 접근 가능하도록 해결했습니다.

### 주요 기능
- 권한 기반 라우팅: `requiresAuth` 플래그로 메뉴 접근 제어.
- 로그인 안내: 비로그인 사용자가 제한된 메뉴 접근 시 `LoginRequiredPopover`로 안내.
- 사용자 정보 표시: 로그인 시 `UserInfo` 컴포넌트로 프로필 정보 표시.

### 새로 추가된 컴포넌트
- `Sidebar`: 메인 사이드바 컴포넌트.
  - `SIDEBAR_ROUTES` 배열을 별도로 분리하지 않은 이유는 사이드바 외에 재사용 가능성이 없어 불필요한 추상화라고 판단했습니다.
- `LoginRequiredPopover`: 로그인 필요 안내 팝오버.
- `UserInfo`: 로그인 사용자 정보 표시.

### 그 외 변경사항
- 기존에 헤더가 로그인 상태를 조회했던 이유는, 렌더링 시점에 사용자에게 로그인 버튼을 보여줄, 마이페이지 버튼을 보여줄지 판단하기 위함이었습니다.
- 사용자에게 HTML이 도착한 뒤, 깜빡이는 문제를 방지하기 위함이었는데요.
- 하지만 현재 사이드바의 경우 클라이언트에 도착한 후 사용자가 햄버거 버튼을 클릭하기 전까지 깜빡임 등의 문제가 발생하지 않아 사이드바가 직접 로그인 상태를 조회하도록 변경했습니다.

## 🛠️ PR 유형

- [X] 새로운 기능 추가

## 📸스크린샷

<div align="center">

| 데스크탑 UI |
| -- |
| <img src="https://github.com/user-attachments/assets/a49c427b-ab91-47ba-9033-7f38a4941f81" width="600px" /> |

| 모바일 UI |
|-- |
| <img src="https://github.com/user-attachments/assets/869f6960-5dc4-4a50-81b8-e4497c00109e" width="600px" /> |

| 비로그인 사용자 UI |
|-- |
| <img src="https://github.com/user-attachments/assets/fe963950-3016-45d5-b8a9-87593b057db0" width="600px" /> |

| 비로그인 사용자 로그인 유도 팝업 UI |
|-- |
| <img src="https://github.com/user-attachments/assets/8dbdacf8-2ac9-4833-846e-fdbb9e713e81" width="600px" /> |

| 네비게이션 |
|-- |
| <img src="https://github.com/user-attachments/assets/ce652f0c-7118-407a-ab67-9eb2d0ab49f8" width="600px" /> |

</div>
