### PR TITLE
Feat(카테고리 검색 페이지) - 돋보기 버튼 클릭 시 화면 우측 슬라이드로 검색바를 표시

### DIFF
--- a/src/features/reviews/category/ui/CategoryReviews.tsx
+++ b/src/features/reviews/category/ui/CategoryReviews.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import ReviewsWithScroll from './ReviewWithScroll';
-import {SearchBar} from '@/features/reviews/search-bar';
 import {CategoryBar, useSelectCategoryFromUrl} from '@/features/reviews/filtering';
 import {SelectSortOptions, useSelectSortOption} from '@/features/reviews/sorting';
 import {ReviewsLoading} from '@/entities/reviews';
@@ -22,7 +21,6 @@ export default function CategoryReviews() {
       <article className="px-3">
         <CategoryBar selectedCategory={selectedCategory} onSelectCategory={handleSelectCategory} />
       </article>
-      <SearchBar />
       <article className="px-6 mb-10">
         <SelectSortOptions className="ml-auto mt-10 mb-7 md:mr-4" sort={sort} onValueChange={handleChange} />
         <RQProvider

--- a/src/features/reviews/search-bar/ui/SearchBar.tsx
+++ b/src/features/reviews/search-bar/ui/SearchBar.tsx
@@ -8,9 +8,10 @@ import {LucideIcon} from '@/shared/ui/icons';
 
 type Props = {
   autoFocus?: boolean;
+  closeDrawer?: () => void;
 };
 
-export default function SearchBar({autoFocus}: Props) {
+export default function SearchBar({autoFocus, closeDrawer}: Props) {
   const router = useRouter();
   const searchInputRef = useRef<HTMLInputElement>(null);
 
@@ -45,6 +46,7 @@ export default function SearchBar({autoFocus}: Props) {
           aria-label="검색어 입력"
           onChange={clearError}
           autoFocus={autoFocus}
+          onBlur={closeDrawer}
         />
       </form>
       {error && <p className="absolute -bottom-7 text-[14px] md:-bottom-8 md:text-[16px] text-red-500">{error}</p>}

--- a/src/features/reviews/search-bar/ui/SearchBar.tsx
+++ b/src/features/reviews/search-bar/ui/SearchBar.tsx
@@ -8,10 +8,10 @@ import {LucideIcon} from '@/shared/ui/icons';
 
 type Props = {
   autoFocus?: boolean;
-  closeDrawer?: () => void;
+  onBlur?: () => void;
 };
 
-export default function SearchBar({autoFocus, closeDrawer}: Props) {
+export default function SearchBar({autoFocus, onBlur}: Props) {
   const router = useRouter();
   const searchInputRef = useRef<HTMLInputElement>(null);
 
@@ -46,7 +46,7 @@ export default function SearchBar({autoFocus, closeDrawer}: Props) {
           aria-label="검색어 입력"
           onChange={clearError}
           autoFocus={autoFocus}
-          onBlur={closeDrawer}
+          onBlur={onBlur}
         />
       </form>
       {error && <p className="absolute -bottom-7 text-[14px] md:-bottom-8 md:text-[16px] text-red-500">{error}</p>}

--- a/src/features/reviews/search-bar/ui/SearchBar.tsx
+++ b/src/features/reviews/search-bar/ui/SearchBar.tsx
@@ -6,7 +6,11 @@ import useSearchValidate from '../lib/useSearchValidate';
 import {Input} from '@/shared/shadcnComponent/ui/input';
 import {LucideIcon} from '@/shared/ui/icons';
 
-export default function SearchBar() {
+type Props = {
+  autoFocus?: boolean;
+};
+
+export default function SearchBar({autoFocus}: Props) {
   const router = useRouter();
   const searchInputRef = useRef<HTMLInputElement>(null);
 
@@ -40,6 +44,7 @@ export default function SearchBar() {
           placeholder="후기를 검색하세요"
           aria-label="검색어 입력"
           onChange={clearError}
+          autoFocus={autoFocus}
         />
       </form>
       {error && <p className="absolute -bottom-7 text-[14px] md:-bottom-8 md:text-[16px] text-red-500">{error}</p>}

--- a/src/shared/shadcnComponent/ui/sheet.tsx
+++ b/src/shared/shadcnComponent/ui/sheet.tsx
@@ -21,7 +21,7 @@ const SheetOverlay = React.forwardRef<
 >(({className, ...props}, ref) => (
   <SheetPrimitive.Overlay
     className={cn(
-      'fixed inset-0 z-50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      'fixed inset-0 z-50 bg-black/65 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
       className,
     )}
     {...props}

--- a/src/views/search/ui/CategorySearchPage.tsx
+++ b/src/views/search/ui/CategorySearchPage.tsx
@@ -1,10 +1,14 @@
 import {CategoryReviews} from '@/features/reviews/category';
 import FloatingWriteButton from './FloatingWriteButton';
+import SearchDrawer from './SearchDrawer';
 
 export default function CategorySearchPage() {
   return (
     <section className="flex flex-col md:px-8 max-w-5xl mx-auto">
-      <h4 className="font-bold text-2xl mt-3 md:mt-6 mb-4 md:mb-6 md:text-3xl ml-7"> 후기글 모음 </h4>
+      <header className="flex items-center justify-between mt-3 md:mt-6 mb-4 md:mb-6 pl-7 pr-10">
+        <h4 className="font-bold text-2xl md:text-3xl"> 후기글 모음 </h4>
+        <SearchDrawer />
+      </header>
       <CategoryReviews />
       <FloatingWriteButton />
     </section>

--- a/src/views/search/ui/CategorySearchPage.tsx
+++ b/src/views/search/ui/CategorySearchPage.tsx
@@ -5,7 +5,7 @@ import SearchDrawer from './SearchDrawer';
 export default function CategorySearchPage() {
   return (
     <section className="flex flex-col md:px-8 max-w-5xl mx-auto">
-      <header className="flex items-center justify-between mt-3 md:mt-6 mb-4 md:mb-6 pl-7 pr-10">
+      <header className="flex items-center justify-between mt-4 md:mt-6 mb-4 md:mb-6 pl-7 pr-10">
         <h4 className="font-bold text-2xl md:text-3xl"> 후기글 모음 </h4>
         <SearchDrawer />
       </header>

--- a/src/views/search/ui/KeywordSearchPage.tsx
+++ b/src/views/search/ui/KeywordSearchPage.tsx
@@ -14,7 +14,7 @@ export default async function KeywordSearchPage({params}: Props) {
 
   return (
     <section className="w-full h-full md:px-8 md:max-w-5xl mx-auto mt-2">
-      <header className="flex flex-col gap-2 mt-3 md:mt-6 mb-6 md:mb-8 ml-7 md:flex-row md:items-center md:justify-between">
+      <header className="flex flex-col gap-2 mt-4 md:mt-6 mb-6 md:mb-8 ml-7 md:flex-row md:items-center md:justify-between">
         <h2 className="font-bold text-2xl md:text-3xl">{decodedQuery} 검색 결과</h2>
         <Link href="/search" className="text-sm text-boldBlue hover:text-extraboldBlue transition-colors md:mr-4">
           카테고리별로 확인해보세요 →

--- a/src/views/search/ui/SearchDrawer.tsx
+++ b/src/views/search/ui/SearchDrawer.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import {SearchBar} from '@/features/reviews/search-bar';
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from '@/shared/shadcnComponent/ui/sheet';
+import {LucideIcon} from '@/shared/ui/icons';
+
+export default function SearchDrawer() {
+  return (
+    <Sheet>
+      <SheetTrigger className="hover:text-boldBlue hover:scale-105 transition-all">
+        <LucideIcon name="Search" className="w-6 h-6 md:w-8 md:h-8" />
+      </SheetTrigger>
+      <SheetContent side="right" className="w-full md:min-w-[500px]">
+        <div className="w-full max-w-3xl mx-auto pb-6">
+          <SheetHeader className="mb-6 md:mb-8">
+            <SheetTitle className="text-xl font-semibold md:text-2xl">후기 검색</SheetTitle>
+            <SheetDescription className="md:text-base">원하는 키워드로 후기를 검색해보세요.</SheetDescription>
+          </SheetHeader>
+          <SearchBar />
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/src/views/search/ui/SearchDrawer.tsx
+++ b/src/views/search/ui/SearchDrawer.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import {useState} from 'react';
 import {SearchBar} from '@/features/reviews/search-bar';
 import {
   Sheet,
@@ -12,8 +13,14 @@ import {
 import {LucideIcon} from '@/shared/ui/icons';
 
 export default function SearchDrawer() {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleCloseDrawer = () => {
+    setIsOpen(false);
+  };
+
   return (
-    <Sheet>
+    <Sheet open={isOpen} onOpenChange={setIsOpen}>
       <SheetTrigger className="hover:text-boldBlue hover:scale-105 transition-all">
         <LucideIcon name="Search" className="w-6 h-6 md:w-8 md:h-8" />
       </SheetTrigger>
@@ -23,7 +30,7 @@ export default function SearchDrawer() {
             <SheetTitle className="text-xl font-semibold md:text-2xl">후기 검색</SheetTitle>
             <SheetDescription className="md:text-base">원하는 키워드로 후기를 검색해보세요.</SheetDescription>
           </SheetHeader>
-          <SearchBar autoFocus={true} />
+          <SearchBar autoFocus={true} closeDrawer={handleCloseDrawer} />
         </div>
       </SheetContent>
     </Sheet>

--- a/src/views/search/ui/SearchDrawer.tsx
+++ b/src/views/search/ui/SearchDrawer.tsx
@@ -21,7 +21,7 @@ export default function SearchDrawer() {
 
   return (
     <Sheet open={isOpen} onOpenChange={setIsOpen}>
-      <SheetTrigger className="hover:text-boldBlue hover:scale-105 transition-all">
+      <SheetTrigger className="hover:text-boldBlue hover:scale-105 transition-all" aria-label="키워드로 후기 검색">
         <LucideIcon name="Search" className="w-6 h-6 md:w-8 md:h-8" />
       </SheetTrigger>
       <SheetContent side="right" className="w-full md:min-w-[500px]">
@@ -31,6 +31,9 @@ export default function SearchDrawer() {
             <SheetDescription className="md:text-base">원하는 키워드로 후기를 검색해보세요.</SheetDescription>
           </SheetHeader>
           <SearchBar autoFocus={true} closeDrawer={handleCloseDrawer} />
+          <p className="mt-8 md:mt-14 md:text-lg text-muted-foreground text-center">
+            검색어를 입력하고 엔터를 눌러주세요.
+          </p>
         </div>
       </SheetContent>
     </Sheet>

--- a/src/views/search/ui/SearchDrawer.tsx
+++ b/src/views/search/ui/SearchDrawer.tsx
@@ -23,7 +23,7 @@ export default function SearchDrawer() {
             <SheetTitle className="text-xl font-semibold md:text-2xl">후기 검색</SheetTitle>
             <SheetDescription className="md:text-base">원하는 키워드로 후기를 검색해보세요.</SheetDescription>
           </SheetHeader>
-          <SearchBar />
+          <SearchBar autoFocus={true} />
         </div>
       </SheetContent>
     </Sheet>

--- a/src/views/search/ui/SearchDrawer.tsx
+++ b/src/views/search/ui/SearchDrawer.tsx
@@ -30,7 +30,7 @@ export default function SearchDrawer() {
             <SheetTitle className="text-xl font-semibold md:text-2xl">후기 검색</SheetTitle>
             <SheetDescription className="md:text-base">원하는 키워드로 후기를 검색해보세요.</SheetDescription>
           </SheetHeader>
-          <SearchBar autoFocus={true} closeDrawer={handleCloseDrawer} />
+          <SearchBar autoFocus={true} onBlur={handleCloseDrawer} />
           <p className="mt-8 md:mt-14 md:text-lg text-muted-foreground text-center">
             검색어를 입력하고 엔터를 눌러주세요.
           </p>


### PR DESCRIPTION
## 📝 요약(Summary)

- shadcn/ui sheet 컴포넌트 기반 사이드 드로어 검색 인터페이스 구현.
- 데스크톱: 우측 슬라이드, 모바일: 전체 화면.
- 기존 인라인 검색바 대비 화면의 답답함 해소 가능.

### `src/features/reviews/search-bar/ui/SearchBar.tsx`
- **input** 태그의 `autoFocus` 여부를 인자로 받을 수 있도록 변경.
- **input** 태그의 `onBlur` 콜백을 인자로 받을 수 있도록 변경.

### `src/views/search/ui/SearchDrawer.tsx`
- `useState`를 사용해 `Sheet` 컴포넌트의 열림/닫힘 상태 제어.
- `SearchBar` 컴포넌트의 **input** 태그가 포커스를 잃을 때 발생하는 `onBlur` 이벤트로 전달할 `handleCloseDrawer` 함수 정의 및 전달.

### `src/features/reviews/category/ui/CategoryReviews.tsx`
- `SearchBar` 제거.

### `src/views/search/ui/CategorySearchPage.tsx`
- `SearchDrawer` 컴포넌트를 사용하도록 변경.

## 🛠️ PR 유형

- [X] 새로운 기능 추가

## 📸스크린샷

<div align="center">

| 드로어 - 데스크탑 |
| -- |
| <img src="https://github.com/user-attachments/assets/c47d53e0-3b8f-4d5e-8943-e2a7d53c7436" width="600px" /> |

| 드로어 - 모바일 |
| -- |
| <img src="https://github.com/user-attachments/assets/8bb80a11-adf4-40e7-9d1f-4735fb3c2b1f" width="600px" /> |

| 드로어 - 모바일 자동 닫기 |
| -- |
| <img src="https://github.com/user-attachments/assets/abe06d9b-9609-45b6-b416-228c82172e71" width="600px" /> |

</div>