### PR TITLE
Style(마이페이지) - 마이페이지 디자인 변경

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3998,7 +3998,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.24.0(eslint@9.20.1(jiti@1.21.7))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@9.20.1(jiti@1.21.7)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.24.0(eslint@9.20.1(jiti@1.21.7))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@9.20.1(jiti@1.21.7)))(eslint@9.20.1(jiti@1.21.7)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -4020,7 +4020,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.20.1(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.24.0(eslint@9.20.1(jiti@1.21.7))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@9.20.1(jiti@1.21.7))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.24.0(eslint@9.20.1(jiti@1.21.7))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@9.20.1(jiti@1.21.7)))(eslint@9.20.1(jiti@1.21.7))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3

--- a/src/entities/reviews/ui/CardDescription.tsx
+++ b/src/entities/reviews/ui/CardDescription.tsx
@@ -9,43 +9,7 @@ const imageWrapperVariants = cva('w-[140px] h-[140px] overflow-hidden rounded-[3
   variants: {
     variant: {
       default: 'shadow-black',
-      my: 'lg:w-[160px] lg:h-[160px] shadow-extraboldBlue',
-    },
-  },
-  defaultVariants: {
-    variant: 'default',
-  },
-});
-
-const titleVariants = cva('mt-4 mb-2 px-3 line-clamp-1', {
-  variants: {
-    variant: {
-      default: '',
-      my: 'lg:text-lg',
-    },
-  },
-  defaultVariants: {
-    variant: 'default',
-  },
-});
-
-const previewVariants = cva('text-[13px] font-light line-clamp-2 px-5', {
-  variants: {
-    variant: {
-      default: 'md:line-clamp-2',
-      my: '2xl:line-clamp-3 lg:px-8',
-    },
-  },
-  defaultVariants: {
-    variant: 'default',
-  },
-});
-
-const authorVariants = cva('text-boldBlue text-sm', {
-  variants: {
-    variant: {
-      default: '',
-      my: 'lg:text-base',
+      my: 'shadow-gray-400',
     },
   },
   defaultVariants: {
@@ -79,13 +43,13 @@ export default function CardDescription({
             alt={`카드 이미지: ${title}`}
           />
         </div>
-        <h3 className={cn(titleVariants({variant}))}>{title}</h3>
+        <h3 className="mt-4 mb-2 px-3 line-clamp-1">{title}</h3>
         <div className="min-h-[30px]">
-          <p className={cn(previewVariants({variant}))}>{preview}</p>
+          <p className="text-[13px] font-light line-clamp-2 px-5">{preview}</p>
         </div>
       </div>
 
-      <p className={cn(authorVariants({variant}))}>{author_id}</p>
+      <p className="text-boldBlue text-sm">{author_id}</p>
 
       <div className="flex mb-5 gap-7 text-sm font-normal">
         <div className="flex gap-1 items-center">

--- a/src/features/auth/index.ts
+++ b/src/features/auth/index.ts
@@ -3,3 +3,4 @@ export {default as useGoLoginPage} from './lib/useGoLoginPage';
 export {default as LoginButton} from './ui/LoginButton';
 export {default as LoginButtonLoading} from './ui/LoginButtonLoading';
 export {default as LoginModal} from './ui/LoginModal';
+export {default as LogoutButton} from './ui/LogoutButton';

--- a/src/features/auth/ui/LogoutButton.tsx
+++ b/src/features/auth/ui/LogoutButton.tsx
@@ -1,0 +1,29 @@
+import {useLogout} from '@/entities/auth';
+import {Tooltip, TooltipContent, TooltipProvider, TooltipTrigger} from '@/shared/shadcnComponent/ui/tooltip';
+import {LucideIcon} from '@/shared/ui/icons';
+
+export default function LogoutButton() {
+  const {logout} = useLogout();
+
+  const handleLogout = () => {
+    logout();
+  };
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            onClick={handleLogout}
+            aria-label="로그아웃"
+            className="text-boldBlue hover:text-extraboldBlue hover:scale-105 transition-all"
+          >
+            <LucideIcon name="LogOut" size={24} />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="top">로그아웃</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/src/features/reviews/my/ui/Empty.tsx
+++ b/src/features/reviews/my/ui/Empty.tsx
@@ -8,7 +8,7 @@ type Props = {
 
 export default function Empty({linkText, linkHref, title}: Props) {
   return (
-    <section className="w-full h-[290px] md:h-[420px] pb-10 md:pb-0 flex flex-col justify-center items-center">
+    <section className="w-full h-[350px] md:h-[420px] pb-10 flex flex-col justify-center items-center">
       <p className="text-lg md:text-xl font-semibold mb-2 text-boldBlue">{title}</p>
       <Link
         href={linkHref}

--- a/src/features/reviews/my/ui/MyBookmarkedReviews.tsx
+++ b/src/features/reviews/my/ui/MyBookmarkedReviews.tsx
@@ -23,7 +23,7 @@ export default function MyBookmarkedReviews({currentPage}: Props) {
         currentPage={currentPage}
         totalPages={total_pages}
         generateUrl={(page: number) => `?tabs=myBookmarks&page=${page}`}
-        className="bg-white px-1.5 md:px-5 py-1.5 rounded-md shadow-md mb-6 mt-8"
+        className="bg-white px-1.5 md:px-5 py-1.5 rounded-md shadow-md mb-6 mt-10 md:mt-16"
       />
     </section>
   );

--- a/src/features/reviews/my/ui/MyBookmarkedReviews.tsx
+++ b/src/features/reviews/my/ui/MyBookmarkedReviews.tsx
@@ -24,7 +24,6 @@ export default function MyBookmarkedReviews({currentPage}: Props) {
         totalPages={total_pages}
         generateUrl={(page: number) => `?tabs=myBookmarks&page=${page}`}
         className="bg-white px-1.5 md:px-5 py-1.5 rounded-md shadow-md mb-6 mt-8"
-        scrollToTop={false}
       />
     </section>
   );

--- a/src/features/reviews/my/ui/MyBookmarkedReviews.tsx
+++ b/src/features/reviews/my/ui/MyBookmarkedReviews.tsx
@@ -23,7 +23,7 @@ export default function MyBookmarkedReviews({currentPage}: Props) {
         currentPage={currentPage}
         totalPages={total_pages}
         generateUrl={(page: number) => `?tabs=myBookmarks&page=${page}`}
-        className="bg-white px-1.5 md:px-5 py-1.5 rounded-md shadow-md mb-4 absolute bottom-0"
+        className="bg-white px-1.5 md:px-5 py-1.5 rounded-md shadow-md mb-6 mt-8"
         scrollToTop={false}
       />
     </section>

--- a/src/features/reviews/my/ui/MyReviewCard.tsx
+++ b/src/features/reviews/my/ui/MyReviewCard.tsx
@@ -24,7 +24,7 @@ export default function MyReviewCard({card, isAuthor, context, priority}: Props)
   };
 
   return (
-    <article className="relative bg-white rounded-[2rem] pt-4 w-[325px] h-[410px] md:w-[300px] md:h-[400px] lg:w-[310px] lg:h-[420px] xl:w-[330px] xl:h-[440px] shadow-md shadow-mediumBlue hover:translate-y-[-2px] hover:shadow-lg hover:shadow-boldBlue transition-all">
+    <article className="relative bg-white rounded-[2rem] pt-4 w-[325px] h-[410px] md:w-[300px] md:h-[400px] shadow-md shadow-gray-400 hover:translate-y-[-2px] hover:shadow-lg hover:shadow-gray-500 transition-all">
       {isPending && (
         <div className="absolute inset-0 bg-black/60 rounded-xl z-50">
           <LoadingSpinner text="리뷰를 삭제하고 있어요." className="text-white mt-3" textSize="text-xl" />

--- a/src/features/reviews/my/ui/MyReviewCardLoading.tsx
+++ b/src/features/reviews/my/ui/MyReviewCardLoading.tsx
@@ -2,16 +2,16 @@ import {Skeleton} from '@/shared/shadcnComponent/ui/skeleton';
 
 export default function MyReviewCardLoading() {
   return (
-    <section className="flex flex-col items-center justify-between rounded-xl py-4 w-[325px] h-[410px] md:w-[300px] md:h-[400px] lg:w-[310px] lg:h-[420px] xl:w-[330px] xl:h-[440px] bg-white shadow-lg">
-      <div className="w-full px-3 flex justify-between items-center">
+    <section className="flex flex-col items-center justify-between rounded-[2rem] py-4 w-[325px] h-[410px] md:w-[300px] md:h-[400px] bg-white shadow-lg">
+      <div className="w-full px-4 flex justify-between items-center">
         <Skeleton className="w-[30px] h-[20px]" />
         <Skeleton className="w-[100px] h-[25px]" />
         <Skeleton className="w-[30px] h-[20px]" />
       </div>
       <div className="flex flex-col items-center">
-        <Skeleton className="rounded-[30px] w-[140px] h-[140px] lg:w-[160px] lg:h-[160px] mt-1 xl:mt-3 mb-5" />
+        <Skeleton className="rounded-[30px] w-[140px] h-[140px] mt-2 mb-5" />
         <Skeleton className="w-[180px] h-[25px] mb-4" />
-        <Skeleton className="w-[250px] h-[40px] xl:h-[55px] mb-2" />
+        <Skeleton className="w-[250px] h-[40px] mb-2" />
       </div>
       <Skeleton className="w-[70px] h-[25px]" />
       <Skeleton className="w-[110px] h-[25px]" />

--- a/src/features/reviews/my/ui/MyReviews.tsx
+++ b/src/features/reviews/my/ui/MyReviews.tsx
@@ -22,7 +22,6 @@ export default function MyReviews({currentPage}: Props) {
         totalPages={total_pages}
         generateUrl={(page: number) => `?tabs=my&page=${page}`}
         className="bg-white px-1.5 md:px-5 py-1.5 rounded-md shadow-md mb-6 mt-8"
-        scrollToTop={false}
       />
     </section>
   );

--- a/src/features/reviews/my/ui/MyReviews.tsx
+++ b/src/features/reviews/my/ui/MyReviews.tsx
@@ -21,7 +21,7 @@ export default function MyReviews({currentPage}: Props) {
         currentPage={currentPage}
         totalPages={total_pages}
         generateUrl={(page: number) => `?tabs=my&page=${page}`}
-        className="bg-white px-1.5 md:px-5 py-1.5 rounded-md shadow-md mb-6 mt-8"
+        className="bg-white px-1.5 md:px-5 py-1.5 rounded-md shadow-md mb-6 mt-10 md:mt-16"
       />
     </section>
   );

--- a/src/features/reviews/my/ui/MyReviews.tsx
+++ b/src/features/reviews/my/ui/MyReviews.tsx
@@ -21,7 +21,7 @@ export default function MyReviews({currentPage}: Props) {
         currentPage={currentPage}
         totalPages={total_pages}
         generateUrl={(page: number) => `?tabs=my&page=${page}`}
-        className="bg-white px-1.5 md:px-5 py-1.5 rounded-md shadow-md mb-4 absolute bottom-0"
+        className="bg-white px-1.5 md:px-5 py-1.5 rounded-md shadow-md mb-6 mt-8"
         scrollToTop={false}
       />
     </section>

--- a/src/features/reviews/my/ui/MyReviewsGrid.tsx
+++ b/src/features/reviews/my/ui/MyReviewsGrid.tsx
@@ -16,7 +16,7 @@ export default function MyReviewsGrid(props: Props) {
   const {reviews, context} = props;
 
   return (
-    <ul className="w-full grid content-center justify-items-center md:grid-cols-[repeat(auto-fit,minmax(350px,1fr))] lg:grid-cols-[repeat(auto-fit,minmax(360px,1fr))] xl:md:grid-cols-[repeat(auto-fit,minmax(420px,1fr))] gap-y-10 lg:gap-y-12 xl:gap-y-14 mb-24">
+    <ul className="w-full grid content-center justify-items-center grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-y-14 md:gap-y-10">
       {reviews.map((card, index) => {
         const isAuthor = context === 'my' || card.author_email === props.userEmail;
         const shouldPrioritize = index < 3;

--- a/src/features/reviews/my/ui/MyReviewsGridLoading.tsx
+++ b/src/features/reviews/my/ui/MyReviewsGridLoading.tsx
@@ -2,7 +2,7 @@ import MyReviewCardLoading from './MyReviewCardLoading';
 
 export default function MyReviewsGridLoading() {
   return (
-    <ul className="w-full grid content-center justify-items-center md:grid-cols-[repeat(auto-fit,minmax(350px,1fr))] lg:grid-cols-[repeat(auto-fit,minmax(360px,1fr))] xl:md:grid-cols-[repeat(auto-fit,minmax(420px,1fr))] gap-y-10 lg:gap-y-12 xl:gap-y-14 mb-24">
+    <ul className="w-full grid content-center justify-items-center grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-y-14 md:gap-y-10">
       {Array.from({length: 6}).map((_, index) => (
         <MyReviewCardLoading key={index} />
       ))}

--- a/src/shared/shadcnComponent/ui/tabs.tsx
+++ b/src/shared/shadcnComponent/ui/tabs.tsx
@@ -46,7 +46,13 @@ TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
 const TabsContent = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
->(({className, ...props}, ref) => <TabsPrimitive.Content ref={ref} className={cn('mt-2', className)} {...props} />);
+>(({className, ...props}, ref) => (
+  <TabsPrimitive.Content
+    ref={ref}
+    className={cn('mt-2 bg-gray-100 md:rounded-2xl pt-6 md:pt-8', className)}
+    {...props}
+  />
+));
 TabsContent.displayName = TabsPrimitive.Content.displayName;
 
 export {Tabs, TabsList, TabsTrigger, TabsContent};

--- a/src/shared/shadcnComponent/ui/tabs.tsx
+++ b/src/shared/shadcnComponent/ui/tabs.tsx
@@ -1,55 +1,52 @@
-"use client"
+'use client';
 
-import * as React from "react"
-import * as TabsPrimitive from "@radix-ui/react-tabs"
+import * as React from 'react';
+import * as TabsPrimitive from '@radix-ui/react-tabs';
 
-import { cn } from "@/shared/lib/utils/cn"
+import {cn} from '@/shared/lib/utils/cn';
 
-const Tabs = TabsPrimitive.Root
+const tabsTriggerActiveAfterContent =
+  'data-[state=active]:after:absolute data-[state=active]:after:-top-1.5 md:data-[state=active]:after:-top-2 data-[state=active]:after:animate-fade-in data-[state=active]:after:w-[8px] md:data-[state=active]:after:w-[9px] data-[state=active]:after:h-[8px] md:data-[state=active]:after:h-[9px] data-[state=active]:after:rounded-full data-[state=active]:after:bg-boldBlue';
+
+const tabsTriggerBaseStyle =
+  'relative inline-flex w-[100px] md:w-[120px] lg:w-[140px] text-gray-400 mx-auto items-center justify-center whitespace-nowrap px-3 py-1 md:text-lg lg:text-xl font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border-b-[4px] border-white';
+
+const tabsTriggerActiveStyle =
+  'data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:font-bold data-[state=active]:border-b-[3.5px] data-[state=active]:border-boldBlue';
+
+const Tabs = TabsPrimitive.Root;
 
 const TabsList = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.List>,
   React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
->(({ className, ...props }, ref) => (
+>(({className, ...props}, ref) => (
   <TabsPrimitive.List
     ref={ref}
     className={cn(
-      "inline-flex h-9 items-center justify-center rounded-lg bg-muted p-1 text-muted-foreground",
-      className
+      'inline-flex h-9 items-center justify-center rounded-lg bg-white p-1 text-muted-foreground',
+      className,
     )}
     {...props}
   />
-))
-TabsList.displayName = TabsPrimitive.List.displayName
+));
+TabsList.displayName = TabsPrimitive.List.displayName;
 
 const TabsTrigger = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.Trigger>,
   React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
->(({ className, ...props }, ref) => (
+>(({className, ...props}, ref) => (
   <TabsPrimitive.Trigger
     ref={ref}
-    className={cn(
-      "inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow",
-      className
-    )}
+    className={cn(tabsTriggerBaseStyle, tabsTriggerActiveStyle, tabsTriggerActiveAfterContent, className)}
     {...props}
   />
-))
-TabsTrigger.displayName = TabsPrimitive.Trigger.displayName
+));
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
 
 const TabsContent = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
->(({ className, ...props }, ref) => (
-  <TabsPrimitive.Content
-    ref={ref}
-    className={cn(
-      "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-      className
-    )}
-    {...props}
-  />
-))
-TabsContent.displayName = TabsPrimitive.Content.displayName
+>(({className, ...props}, ref) => <TabsPrimitive.Content ref={ref} className={cn('mt-2', className)} {...props} />);
+TabsContent.displayName = TabsPrimitive.Content.displayName;
 
-export { Tabs, TabsList, TabsTrigger, TabsContent }
+export {Tabs, TabsList, TabsTrigger, TabsContent};

--- a/src/shared/shadcnComponent/ui/tabs.tsx
+++ b/src/shared/shadcnComponent/ui/tabs.tsx
@@ -49,7 +49,7 @@ const TabsContent = React.forwardRef<
 >(({className, ...props}, ref) => (
   <TabsPrimitive.Content
     ref={ref}
-    className={cn('mt-2 bg-gray-100 md:rounded-2xl pt-6 md:pt-8', className)}
+    className={cn('mt-2 bg-gray-100 md:rounded-2xl pt-8 md:pt-10 lg:px-8', className)}
     {...props}
   />
 ));

--- a/src/shared/shadcnComponent/ui/tabs.tsx
+++ b/src/shared/shadcnComponent/ui/tabs.tsx
@@ -1,54 +1,55 @@
-'use client';
+"use client"
 
-import * as React from 'react';
-import * as TabsPrimitive from '@radix-ui/react-tabs';
+import * as React from "react"
+import * as TabsPrimitive from "@radix-ui/react-tabs"
 
-import {cn} from '@/shared/lib/utils/cn';
+import { cn } from "@/shared/lib/utils/cn"
 
-const Tabs = TabsPrimitive.Root;
-
-const tabsTriggerDefaultStyle =
-  'inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 lg:py-1.5 text-base md:text-lg lg:text-xl text-boldBlue font-medium border-2 border-mediumBlue focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50 transition-all';
-const tabsTriggerActiveStyle =
-  'data-[state=active]:pb-4 md:data-[state=active]:pb-3.5 data-[state=inactive]:mb-2.5 md:data-[state=inactive]:mb-2 data-[state=active]:bg-lightBlue data-[state=active]:border-lightBlue data-[state=inactive]:hover:bg-lightBlue data-[state=inactive]:hover:text-boldBlue data-[state=inactive]:hover:border-lightBlue data-[state=inactive]:hover:border-lightBlue';
+const Tabs = TabsPrimitive.Root
 
 const TabsList = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.List>,
   React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
->(({className, ...props}, ref) => (
+>(({ className, ...props }, ref) => (
   <TabsPrimitive.List
     ref={ref}
-    className={cn('inline-flex h-9 items-center justify-center rounded-lg bg-white p-1', className)}
+    className={cn(
+      "inline-flex h-9 items-center justify-center rounded-lg bg-muted p-1 text-muted-foreground",
+      className
+    )}
     {...props}
   />
-));
-TabsList.displayName = TabsPrimitive.List.displayName;
+))
+TabsList.displayName = TabsPrimitive.List.displayName
 
 const TabsTrigger = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.Trigger>,
   React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
->(({className, ...props}, ref) => (
+>(({ className, ...props }, ref) => (
   <TabsPrimitive.Trigger
     ref={ref}
-    className={cn(tabsTriggerDefaultStyle, tabsTriggerActiveStyle, className)}
+    className={cn(
+      "inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow",
+      className
+    )}
     {...props}
   />
-));
-TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
+))
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName
 
 const TabsContent = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
->(({className, ...props}, ref) => (
+>(({ className, ...props }, ref) => (
   <TabsPrimitive.Content
     ref={ref}
     className={cn(
-      'mt-2.5 md:mt-3 lg:mt-4 mx-1 p-3 pt-10 md:pt-16 min-h-[45vh] rounded-b-md md:min-h-[58vh] ring-offset-background bg-lightBlue focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
-      className,
+      "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      className
     )}
     {...props}
   />
-));
-TabsContent.displayName = TabsPrimitive.Content.displayName;
+))
+TabsContent.displayName = TabsPrimitive.Content.displayName
 
-export {Tabs, TabsList, TabsTrigger, TabsContent};
+export { Tabs, TabsList, TabsTrigger, TabsContent }

--- a/src/shared/ui/components/Badge.tsx
+++ b/src/shared/ui/components/Badge.tsx
@@ -4,7 +4,7 @@ import {cva, type VariantProps} from 'class-variance-authority';
 import {cn} from '@/shared/lib/utils/cn';
 
 export const badgeVariants = cva(
-  'inline-flex items-center rounded-full border px-9 py-1 text-sm font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+  'inline-flex justify-center items-center rounded-full border w-[105px] py-1 text-sm font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
   {
     variants: {
       variant: {

--- a/src/views/mypage/ui/MyPage.tsx
+++ b/src/views/mypage/ui/MyPage.tsx
@@ -1,29 +1,14 @@
-import Link from 'next/link';
 import UserInfo from './UserInfo';
 import ReviewTabs from './ReviewTabs';
-import {Sidebar} from '@/widgets/side-bar';
 import checkSession from '@/shared/lib/utils/checkSession';
-import {LucideIcon} from '@/shared/ui/icons';
 
 export default async function MyPage() {
   await checkSession();
 
   return (
-    <section className="fixed inset-0 w-full h-full z-20 bg-white overflow-auto">
+    <section>
       <section className="w-full mb-4 md:mb-8">
         <section className="bg-lightBlue p-4 flex flex-col justify-between mb-[90px] md:mb-[110px] lg:mb-[130px]">
-          <header className="flex items-center justify-between mt-2 px-2 md:px-4">
-            <div className="flex items-center gap-2">
-              <Link href="/" aria-label="메인 페이지로 이동">
-                <LucideIcon
-                  name="House"
-                  className="w-7 h-7 lg:w-8 lg:h-8 text-boldBlue hover:scale-110 transition-transform"
-                />
-              </Link>
-              <h2 className="text-2xl lg:text-3xl text-boldBlue font-bold">마이페이지</h2>
-            </div>
-            <Sidebar />
-          </header>
           <UserInfo />
         </section>
         <ReviewTabs />

--- a/src/views/mypage/ui/MyPage.tsx
+++ b/src/views/mypage/ui/MyPage.tsx
@@ -6,7 +6,7 @@ export default async function MyPage() {
   await checkSession();
 
   return (
-    <section>
+    <section className="w-full max-w-6xl mx-auto">
       <UserInfo />
       <ReviewTabs />
     </section>

--- a/src/views/mypage/ui/MyPage.tsx
+++ b/src/views/mypage/ui/MyPage.tsx
@@ -8,7 +8,7 @@ export default async function MyPage() {
   return (
     <section>
       <section className="w-full mb-4 md:mb-8">
-        <section className="bg-lightBlue p-4 flex flex-col justify-between mb-[90px] md:mb-[110px] lg:mb-[130px]">
+        <section className="p-4 flex flex-col justify-between mb-[90px] md:mb-[110px] lg:mb-[130px]">
           <UserInfo />
         </section>
         <ReviewTabs />

--- a/src/views/mypage/ui/MyPage.tsx
+++ b/src/views/mypage/ui/MyPage.tsx
@@ -7,12 +7,8 @@ export default async function MyPage() {
 
   return (
     <section>
-      <section className="w-full mb-4 md:mb-8">
-        <section className="p-4 flex flex-col justify-between mb-[90px] md:mb-[110px] lg:mb-[130px]">
-          <UserInfo />
-        </section>
-        <ReviewTabs />
-      </section>
+      <UserInfo />
+      <ReviewTabs />
     </section>
   );
 }

--- a/src/views/mypage/ui/MyPage.tsx
+++ b/src/views/mypage/ui/MyPage.tsx
@@ -6,7 +6,7 @@ export default async function MyPage() {
   await checkSession();
 
   return (
-    <section className="w-full max-w-6xl mx-auto">
+    <section className="w-full max-w-[1230px] mx-auto">
       <UserInfo />
       <ReviewTabs />
     </section>

--- a/src/views/mypage/ui/ReviewTabs.tsx
+++ b/src/views/mypage/ui/ReviewTabs.tsx
@@ -29,8 +29,13 @@ export default function ReviewTabs() {
   };
 
   return (
-    <Tabs value={tabValue} onValueChange={handleTabChange} defaultValue="my" className="w-full mt-10 mb-8">
-      <TabsList className="grid w-full grid-cols-2 gap-2 mb-5 md:mb-6">
+    <Tabs
+      value={tabValue}
+      onValueChange={handleTabChange}
+      defaultValue="my"
+      className="w-full mt-10 md:mt-[4.2rem] mb-8"
+    >
+      <TabsList className="grid w-full grid-cols-2 gap-2 mb-7 md:mb-9">
         <TabsTrigger value="my">내가 작성한 후기</TabsTrigger>
         <TabsTrigger value="myBookmarks">내가 저장한 후기</TabsTrigger>
       </TabsList>

--- a/src/views/mypage/ui/ReviewTabs.tsx
+++ b/src/views/mypage/ui/ReviewTabs.tsx
@@ -29,12 +29,7 @@ export default function ReviewTabs() {
   };
 
   return (
-    <Tabs
-      value={tabValue}
-      onValueChange={handleTabChange}
-      defaultValue="my"
-      className="w-full relative mt-6 md:mt-10 mb-8"
-    >
+    <Tabs value={tabValue} onValueChange={handleTabChange} defaultValue="my" className="w-full mt-6 md:mt-10 mb-8">
       <TabsList className="grid w-full grid-cols-2 gap-2 mb-5 md:mb-6">
         <TabsTrigger value="my">내가 작성한 후기</TabsTrigger>
         <TabsTrigger value="myBookmarks">내가 저장한 후기</TabsTrigger>

--- a/src/views/mypage/ui/ReviewTabs.tsx
+++ b/src/views/mypage/ui/ReviewTabs.tsx
@@ -43,8 +43,14 @@ export default function ReviewTabs() {
   }, [currentPage]);
 
   return (
-    <Tabs ref={tabsRef} value={tabValue} onValueChange={handleTabChange} defaultValue="my" className="w-full relative">
-      <TabsList className="grid w-full grid-cols-2 gap-2">
+    <Tabs
+      ref={tabsRef}
+      value={tabValue}
+      onValueChange={handleTabChange}
+      defaultValue="my"
+      className="w-full relative mt-6 md:mt-10 mb-8"
+    >
+      <TabsList className="grid w-full grid-cols-2 gap-2 mb-5 md:mb-6">
         <TabsTrigger value="my">내가 작성한 후기</TabsTrigger>
         <TabsTrigger value="myBookmarks">내가 저장한 후기</TabsTrigger>
       </TabsList>

--- a/src/views/mypage/ui/ReviewTabs.tsx
+++ b/src/views/mypage/ui/ReviewTabs.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import dynamic from 'next/dynamic';
-import {useEffect, useRef} from 'react';
 import {useRouter, useSearchParams} from 'next/navigation';
 import {MyReviewsGridLoading} from '@/features/reviews/my';
 import {Tabs, TabsContent, TabsList, TabsTrigger} from '@/shared/shadcnComponent/ui/tabs';
@@ -25,26 +24,12 @@ export default function ReviewTabs() {
   const tabValue = searchParams.get('tabs') || 'my';
   const currentPage = Number(searchParams.get('page')) || 1;
 
-  const prevPageRef = useRef(currentPage);
-  const tabsRef = useRef<HTMLDivElement>(null);
-
   const handleTabChange = (value: string) => {
     router.push('/mypage?tabs=' + value, {scroll: false});
   };
 
-  useEffect(() => {
-    if (prevPageRef.current && prevPageRef.current !== currentPage) {
-      if (tabsRef.current) {
-        tabsRef.current.scrollIntoView({behavior: 'smooth'});
-      }
-    }
-
-    prevPageRef.current = currentPage;
-  }, [currentPage]);
-
   return (
     <Tabs
-      ref={tabsRef}
       value={tabValue}
       onValueChange={handleTabChange}
       defaultValue="my"

--- a/src/views/mypage/ui/ReviewTabs.tsx
+++ b/src/views/mypage/ui/ReviewTabs.tsx
@@ -29,7 +29,7 @@ export default function ReviewTabs() {
   };
 
   return (
-    <Tabs value={tabValue} onValueChange={handleTabChange} defaultValue="my" className="w-full mt-6 md:mt-10 mb-8">
+    <Tabs value={tabValue} onValueChange={handleTabChange} defaultValue="my" className="w-full mt-10 mb-8">
       <TabsList className="grid w-full grid-cols-2 gap-2 mb-5 md:mb-6">
         <TabsTrigger value="my">내가 작성한 후기</TabsTrigger>
         <TabsTrigger value="myBookmarks">내가 저장한 후기</TabsTrigger>

--- a/src/views/mypage/ui/UserInfo.tsx
+++ b/src/views/mypage/ui/UserInfo.tsx
@@ -9,7 +9,7 @@ export default function UserInfo() {
   const userEmail = useUserEmail();
 
   return (
-    <section className="flex flex-col items-center mt-3 md:mt-5 lg:mt-8">
+    <section className="flex flex-col items-center mt-6 md:mt-8 lg:mt-12">
       <div className="w-40 h-40 md:w-48 md:h-48 lg:w-52 lg:h-52 bg-white flex justify-center items-center rounded-full border-boldBlue border-[7px] overflow-hidden">
         <Image
           // TODO: 실제 사용자 프로필 이미지로 변경

--- a/src/views/mypage/ui/UserInfo.tsx
+++ b/src/views/mypage/ui/UserInfo.tsx
@@ -13,7 +13,7 @@ export default function UserInfo() {
       <div className="w-36 h-36 md:w-40 md:h-40 lg:w-48 lg:h-48 bg-white flex justify-center items-center rounded-full border-boldBlue border-[7px] overflow-hidden">
         <Image
           // TODO: 실제 사용자 프로필 이미지로 변경
-          src="https://picsum.photos/200/200"
+          src="https://picsum.photos/seed/ee2/200/200"
           alt={`${userId} 프로필 사진`}
           width={160}
           height={160}
@@ -23,12 +23,12 @@ export default function UserInfo() {
       </div>
       <div className="flex flex-col items-center mt-3">
         {userId ? (
-          <p className="text-lg md:text-xl font-bold">{userId}</p>
+          <p className="text-lg md:text-xl lg:text-2xl font-bold">{userId}</p>
         ) : (
-          <Skeleton className="h-5 md:h-6 lg:h-7 w-32 md:w-36 lg:w-40 mb-2" />
+          <Skeleton className="h-5 md:h-6 lg:h-7 w-32 md:w-36 lg:w-40 mb-1 mt-2 md:mt-0" />
         )}
         {userEmail ? (
-          <p className="text-sm md:text-base lg:text-lg font-semibold text-boldBlue">{userEmail}</p>
+          <p className="text-sm md:text-base font-semibold text-boldBlue">{userEmail}</p>
         ) : (
           <Skeleton className="h-4 md:h-5 lg:h-6 w-40 md:w-48 lg:w-52" />
         )}

--- a/src/views/mypage/ui/UserInfo.tsx
+++ b/src/views/mypage/ui/UserInfo.tsx
@@ -9,8 +9,8 @@ export default function UserInfo() {
   const userEmail = useUserEmail();
 
   return (
-    <section className="">
-      <div className="w-36 h-36 md:w-40 md:h-40 lg:w-48 lg:h-48 bg-white flex justify-center items-center rounded-full border-lightBlue border-[6px] overflow-hidden">
+    <section className="flex flex-col items-center mt-3 md:mt-5 lg:mt-8">
+      <div className="w-40 h-40 md:w-48 md:h-48 lg:w-52 lg:h-52 bg-white flex justify-center items-center rounded-full border-boldBlue border-[7px] overflow-hidden">
         <Image
           // TODO: 실제 사용자 프로필 이미지로 변경
           src="https://picsum.photos/200/200"
@@ -21,14 +21,14 @@ export default function UserInfo() {
           priority
         />
       </div>
-      <div className="">
+      <div className="flex flex-col items-center mt-3">
         {userId ? (
-          <p className="text-lg md:text-xl lg:text-2xl text-boldBlue font-semibold mb-1 md:mb-2">{userId}</p>
+          <p className="text-lg md:text-xl lg:text-2xl font-bold mb-1">{userId}</p>
         ) : (
           <Skeleton className="h-5 md:h-6 lg:h-7 w-32 md:w-36 lg:w-40 mb-3" />
         )}
         {userEmail ? (
-          <p className="text-sm md:text-base lg:text-lg text-boldBlue">{userEmail}</p>
+          <p className="text-sm md:text-base lg:text-lg font-semibold text-boldBlue">{userEmail}</p>
         ) : (
           <Skeleton className="h-4 md:h-5 lg:h-6 w-40 md:w-48 lg:w-52" />
         )}

--- a/src/views/mypage/ui/UserInfo.tsx
+++ b/src/views/mypage/ui/UserInfo.tsx
@@ -1,22 +1,16 @@
 'use client';
 
 import Image from 'next/image';
-import {useLogout, useUserEmail, useUserId} from '@/entities/auth';
-import {Button} from '@/shared/shadcnComponent/ui/button';
+import {useUserEmail, useUserId} from '@/entities/auth';
 import {Skeleton} from '@/shared/shadcnComponent/ui/skeleton';
 
 export default function UserInfo() {
   const userId = useUserId();
   const userEmail = useUserEmail();
-  const {logout} = useLogout();
-
-  const handleLogout = async () => {
-    logout();
-  };
 
   return (
-    <section className="flex ml-2 md:ml-10 lg:ml-16">
-      <div className="translate-y-1/2 w-36 h-36 md:w-40 md:h-40 lg:w-48 lg:h-48 bg-white flex justify-center items-center rounded-full border-lightBlue border-[6px] overflow-hidden">
+    <section className="">
+      <div className="w-36 h-36 md:w-40 md:h-40 lg:w-48 lg:h-48 bg-white flex justify-center items-center rounded-full border-lightBlue border-[6px] overflow-hidden">
         <Image
           // TODO: 실제 사용자 프로필 이미지로 변경
           src="https://picsum.photos/200/200"
@@ -27,7 +21,7 @@ export default function UserInfo() {
           priority
         />
       </div>
-      <div className="mt-auto ml-3 md:ml-5 relative">
+      <div className="">
         {userId ? (
           <p className="text-lg md:text-xl lg:text-2xl text-boldBlue font-semibold mb-1 md:mb-2">{userId}</p>
         ) : (
@@ -38,14 +32,6 @@ export default function UserInfo() {
         ) : (
           <Skeleton className="h-4 md:h-5 lg:h-6 w-40 md:w-48 lg:w-52" />
         )}
-        <Button
-          className="absolute -left-[0.5rem] -bottom-[3.5rem] md:-bottom-[4rem]"
-          variant="logInOut"
-          size="logInOut"
-          onClick={handleLogout}
-        >
-          로그아웃
-        </Button>
       </div>
     </section>
   );

--- a/src/views/mypage/ui/UserInfo.tsx
+++ b/src/views/mypage/ui/UserInfo.tsx
@@ -9,8 +9,8 @@ export default function UserInfo() {
   const userEmail = useUserEmail();
 
   return (
-    <section className="flex flex-col items-center mt-6 md:mt-8 lg:mt-12">
-      <div className="w-40 h-40 md:w-48 md:h-48 lg:w-52 lg:h-52 bg-white flex justify-center items-center rounded-full border-boldBlue border-[7px] overflow-hidden">
+    <section className="flex flex-col items-center mt-6 md:mt-8 lg:mt-10">
+      <div className="w-36 h-36 md:w-40 md:h-40 lg:w-48 lg:h-48 bg-white flex justify-center items-center rounded-full border-boldBlue border-[7px] overflow-hidden">
         <Image
           // TODO: 실제 사용자 프로필 이미지로 변경
           src="https://picsum.photos/200/200"
@@ -23,9 +23,9 @@ export default function UserInfo() {
       </div>
       <div className="flex flex-col items-center mt-3">
         {userId ? (
-          <p className="text-lg md:text-xl lg:text-2xl font-bold mb-1">{userId}</p>
+          <p className="text-lg md:text-xl font-bold">{userId}</p>
         ) : (
-          <Skeleton className="h-5 md:h-6 lg:h-7 w-32 md:w-36 lg:w-40 mb-3" />
+          <Skeleton className="h-5 md:h-6 lg:h-7 w-32 md:w-36 lg:w-40 mb-2" />
         )}
         {userEmail ? (
           <p className="text-sm md:text-base lg:text-lg font-semibold text-boldBlue">{userEmail}</p>

--- a/src/views/mypage/ui/UserInfo.tsx
+++ b/src/views/mypage/ui/UserInfo.tsx
@@ -23,7 +23,7 @@ export default function UserInfo() {
       </div>
       <div className="flex flex-col items-center mt-3">
         {userId ? (
-          <p className="text-lg md:text-xl lg:text-2xl font-bold">{userId}</p>
+          <p className="text-xl lg:text-2xl font-bold">{userId}</p>
         ) : (
           <Skeleton className="h-5 md:h-6 lg:h-7 w-32 md:w-36 lg:w-40 mb-1 mt-2 md:mt-0" />
         )}

--- a/src/widgets/side-bar/ui/Sidebar.tsx
+++ b/src/widgets/side-bar/ui/Sidebar.tsx
@@ -5,7 +5,7 @@ import dynamic from 'next/dynamic';
 import {usePathname} from 'next/navigation';
 import UserInfo from './UserInfo';
 import LoginRequiredPopover from './LoginRequiredPopover';
-import {LoginButtonLoading} from '@/features/auth';
+import {LoginButtonLoading, LogoutButton} from '@/features/auth';
 import {useIsLoggedIn} from '@/entities/auth';
 import {
   Sheet,
@@ -85,7 +85,7 @@ export default function Sidebar() {
       <SheetTrigger aria-label="사이드바 네비게이션 열기">
         <LucideIcon
           name="Menu"
-          className="w-6 h-6 md:w-7 md:h-7 xl:w-8 xl:h-8 hover:text-boldBlue md:hover:scale-105 transition-all"
+          className="w-6 h-6 md:w-7 md:h-7 hover:text-boldBlue md:hover:scale-105 transition-all"
         />
       </SheetTrigger>
       <SheetContent className="w-[300px] flex flex-col">
@@ -115,7 +115,16 @@ export default function Sidebar() {
             ),
           )}
         </nav>
-        <SheetFooter>{isLoggedIn ? <UserInfo /> : <LoginButton />}</SheetFooter>
+        <SheetFooter>
+          {isLoggedIn ? (
+            <section className="w-full flex items-center justify-between">
+              <UserInfo />
+              <LogoutButton />
+            </section>
+          ) : (
+            <LoginButton />
+          )}
+        </SheetFooter>
       </SheetContent>
     </Sheet>
   );

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -96,6 +96,7 @@ export default {
       },
       animation: {
         'fade-up': 'fade-up 150ms ease-in-out',
+        'fade-in': 'fade-in 200ms ease-in',
       },
       keyframes: {
         'fade-up': {
@@ -106,6 +107,14 @@ export default {
           '100%': {
             opacity: '1',
             transform: 'translateY(0)',
+          },
+        },
+        'fade-in': {
+          '0%': {
+            opacity: '0',
+          },
+          '100%': {
+            opacity: '1',
           },
         },
       },


### PR DESCRIPTION
## 📝 요약(Summary)

- 마이페이지 디자인 변경.
- 마이페이지의 fixed 요소 제거.
  - 페이지 영역의 fixed 속성 제거로 Next.js Link 컴포넌트의 scrollToTop 기능을 사용하기 위해 기존 ref를 이용한 수동 스크롤 기능 제거.
  - 최대 넓이를 1230px로 고정.
- 마이페이지 내 로그아웃 버튼 제거, 사이드바 내 로그아웃 버튼 추가.
- 마이페이지 리뷰 카드 크기를 전체적으로 축소.
- 마이페이지 리뷰 카드 축소로 CardDescription 컴포넌트의 cva 속성 제거.

## 🛠️ PR 유형

- [X] CSS 등 사용자 UI 디자인 변경

## 📸스크린샷

<div align="center">

| UI - 데스크탑 |
| -- |
| <img src="https://github.com/user-attachments/assets/869d5629-d5f1-4c36-89a0-741a8fb38d16" width="600px" /> |

| UI - 모바일 |
| -- |
| <img src="https://github.com/user-attachments/assets/cd34b8fb-f43f-4318-90b7-d7d2a4d1ecc2" width="600px" /> |

</div>