### PR TITLE
Fix(세션) - 프론트 세션 검사 시 userEmail 쿠키 대신 userNickname 쿠키를 조회하도록 변경, 전역 auth 스토어에서 userId, userEmail 제거 및 userNickname 속성 추가

### DIFF
--- a/app/api/auth/route.ts
+++ b/app/api/auth/route.ts
@@ -7,25 +7,22 @@ export async function GET() {
   if (!cookieStore.has('refreshToken')) {
     return NextResponse.json({
       isLoggedIn: false,
-      userEmail: null,
-      userId: null,
+      userNickname: null,
     });
   }
 
-  const userEmailCookie = cookieStore.get('userEmail');
+  const userNicknameCookie = cookieStore.get('userNickname');
 
-  if (!userEmailCookie) {
-    return NextResponse.json({errorCode: 'EMPTY_USER_EMAIL'}, {status: 400});
+  if (!userNicknameCookie) {
+    return NextResponse.json({errorCode: 'EMPTY_USER_NICKNAME'}, {status: 400});
   }
 
-  const userEmail = userEmailCookie.value;
-  const userId = userEmail.split('@')[0];
+  const userNickname = userNicknameCookie.value;
 
   return NextResponse.json(
     {
       isLoggedIn: true,
-      userEmail,
-      userId,
+      userNickname,
     },
     {status: 200},
   );

--- a/src/app/providers/AuthProvider.tsx
+++ b/src/app/providers/AuthProvider.tsx
@@ -12,16 +12,14 @@ export default function AuthProvider({children}: Props) {
   const updateUser = useUpdateUser();
 
   useEffect(() => {
-    if (session && session.isLoggedIn) {
+    if (session && session.isLoggedIn && session.userNickname) {
       updateUser({
-        userId: session.userId,
-        userEmail: session.userEmail,
+        userNickname: decodeURIComponent(session.userNickname),
         isLoggedIn: true,
       });
     } else {
       updateUser({
-        userId: null,
-        userEmail: null,
+        userNickname: null,
         isLoggedIn: false,
       });
     }

--- a/src/entities/auth/model/authStore.ts
+++ b/src/entities/auth/model/authStore.ts
@@ -9,15 +9,13 @@ type Action = {
 
 const userStore = create<State & Action>(set => ({
   isLoggedIn: false,
-  userEmail: null,
-  userId: null,
+  userNickname: null,
 
   updateUser: user => set({...user}),
 }));
 
 const useIsLoggedIn = () => userStore(state => state.isLoggedIn);
-const useUserEmail = () => userStore(state => state.userEmail);
-const useUserId = () => userStore(state => state.userId);
+const useUserNickname = () => userStore(state => state.userNickname);
 const useUpdateUser = () => userStore(state => state.updateUser);
 
-export {useIsLoggedIn, useUserEmail, useUserId, useUpdateUser};
+export {useIsLoggedIn, useUserNickname, useUpdateUser};

--- a/src/entities/auth/model/types.ts
+++ b/src/entities/auth/model/types.ts
@@ -1,5 +1,4 @@
 export type User = {
   isLoggedIn: boolean;
-  userEmail: string | null;
-  userId: string | null;
+  userNickname: string | null;
 };

--- a/src/shared/lib/consts/errorMessage.ts
+++ b/src/shared/lib/consts/errorMessage.ts
@@ -3,6 +3,7 @@ type ErrorMessage = Record<string, string>;
 export const SERVER_ERROR_MESSAGE: ErrorMessage = {
   // OAuth2 로그인 에러 - Next.js API Routes
   EMPTY_USER_EMAIL: '이메일 정보를 찾을 수 없어 로그아웃 됐어요. 다시 로그인해주세요.',
+  EMPTY_USER_NICKNAME: '닉네임 정보를 찾을 수 없어 로그아웃 됐어요. 다시 로그인해주세요.',
 
   // 슬랙 메세지 전송 에러
   SLACK_MESSAGE_SEND_ERROR: '슬랙 메세지 전송에 실패했어요. 다시 시도해주세요.',


### PR DESCRIPTION
## 📝 요약(Summary)

- 고유 ID(리뷰어_난수)가 추가되어 `userEmail` 쿠키 대신 `userNickname`(고유 ID)가 프론트로 전달됨에 따라 세션 검사 방식 변경.
  - `/api/auth` 라우트 핸들러에서 `userEmail` 쿠키 유무 대신 `userNickname` 쿠키 유무를 판단하도록 변경.
  - `userEmail` 값을 `split`해 생성하던 `userId`를 제거하며, 반환 값으로 `isLoggedIn`과 `userNickname`만 반환하도록 변경.
- 전역 auth 스토어에서 `userId`, `userEmail` 필드를 제거, `userNickname` 필드 추가.

## 🛠️ PR 유형

- [X] 코드 리팩토링