### PR TITLE
Fix(entities/review) - entities 레이어의 review 도메인에서 닉네임을 사용하도록 수정

### DIFF
--- a/src/entities/review/apis/api-service.ts
+++ b/src/entities/review/apis/api-service.ts
@@ -153,7 +153,7 @@ export async function getReviewComments(reviewId: number, page: number) {
   });
 }
 
-export async function postReviewComment({reviewId, category, content}: CommentPayload) {
+export async function postReviewComment({reviewId, category, content}: Omit<CommentPayload, 'userNickname'>) {
   return requestPost({
     baseUrl: process.env.NEXT_PUBLIC_API_URL,
     endpoint: `/reviews/${reviewId}/comments`,

--- a/src/entities/review/model/type.ts
+++ b/src/entities/review/model/type.ts
@@ -66,6 +66,7 @@ export type BookmarkPayload = {
 };
 
 export type CommentPayload = {
+  userNickname: string;
   category: Category;
   reviewId: number;
   content: string;

--- a/src/entities/review/model/useDeleteReviewComment.ts
+++ b/src/entities/review/model/useDeleteReviewComment.ts
@@ -8,8 +8,7 @@ export default function useDeleteReviewComment() {
   const queryClient = useQueryClient();
 
   const {mutate, ...rest} = useMutation({
-    mutationFn: ({userEmail, commentId, reviewId}: DeleteCommentPayload) =>
-      deleteReviewComment({userEmail, commentId, reviewId}),
+    mutationFn: ({commentId, reviewId}: DeleteCommentPayload) => deleteReviewComment({commentId, reviewId}),
     onSuccess: (_data, {reviewId}) => {
       toast.success({
         title: '댓글을 성공적으로 삭제했어요.',

--- a/src/entities/review/model/usePostReviewComment.ts
+++ b/src/entities/review/model/usePostReviewComment.ts
@@ -11,9 +11,8 @@ export default function usePostReviewComment(page: number) {
   const router = useRouter();
 
   const {mutate, ...rest} = useMutation({
-    mutationFn: ({userEmail, reviewId, category, content}: CommentPayload) =>
-      postReviewComment({userEmail, reviewId, category, content}),
-    onMutate: async ({userEmail, reviewId, content}) => {
+    mutationFn: ({reviewId, category, content}: CommentPayload) => postReviewComment({reviewId, category, content}),
+    onMutate: async ({userNickname, reviewId, content}) => {
       const previousComments = queryClient.getQueryData<ReviewComments>(reviewQueryKeys.comments.page(reviewId, page));
 
       if (!previousComments || page !== previousComments.total_pages) {
@@ -23,7 +22,7 @@ export default function usePostReviewComment(page: number) {
       const newComment = {
         id: Date.now(),
         profile_image: 'https://picsum.photos/seed/picsum/200/200', // TODO: 실제 사용자 프로필 이미지로 변경.
-        author: userEmail,
+        author_nickname: userNickname,
         content,
         created_at: new Date().toISOString(),
       };

--- a/src/entities/review/model/useToggleBookmark.ts
+++ b/src/entities/review/model/useToggleBookmark.ts
@@ -11,11 +11,11 @@ export default function useToggleBookmark() {
   const queryClient = useQueryClient();
 
   const {mutate, ...rest} = useMutation({
-    mutationFn: ({userEmail, reviewId, hasBookmarked}: MutationVariables) => {
+    mutationFn: ({reviewId, hasBookmarked}: MutationVariables) => {
       if (hasBookmarked) {
-        return unBookmarkReview({userEmail, reviewId});
+        return unBookmarkReview({reviewId});
       } else {
-        return bookmarkReview({userEmail, reviewId});
+        return bookmarkReview({reviewId});
       }
     },
     onMutate: async ({reviewId}) => {


### PR DESCRIPTION
## 📝 요약(Summary)

- entities 레이어의 review 도메인에서 닉네임을 사용하도록 수정.

### `src/entities/review/model/type.ts`
- 반환 데이터 타입의 모든 `author_id`, `author_email` 필드를 제거하고 `author_nickname` 필드 추가.
- 북마크 요청, 댓글 요청 시 사용자 판단을 쿠키로 조회하도록 스펙이 변경되어 요청 페이로드 타입에서 `userEmail` 필드를 모두 제거.
- 댓글 요청의 경우 낙관적 업데이트에 사용자 닉네임이 필요해 `userNickname` 필드 추가.

### `src/entities/review/apis/api-service.ts`
- 댓글 등록 및 삭제, 북마크 등록 및 삭제 요청 API에서 `userEmail` 인자를 모두 제거.

### `src/entities/review/model/useToggleBookmark.ts`
### `src/entities/review/model/useDeleteReviewComment.ts`
- `userEmail` 인자 모두 제거.

### `src/entities/review/model/usePostReviewComment.ts` 
- `userEmail` 인자를 제거하고, 낙관적 업데이트에 `author`가 아닌, `author_nickname` 속성으로 `userNickname`을 주입하도록 변경.

## 🛠️ PR 유형

- [X] 코드 리팩토링
