### PR TITLE
Fix(features,entities/reviews) - features, entities 레이어의 reviews 도메인에서 닉네임을 사용하도록 수정

### DIFF
--- a/src/entities/reviews/ui/CardDescription.tsx
+++ b/src/entities/reviews/ui/CardDescription.tsx
@@ -24,7 +24,7 @@ type Props = {
 };
 
 export default function CardDescription({
-  card: {category, image_url, title, preview, author_id, comments_count, bookmarks},
+  card: {category, image_url, title, preview, author_nickname, comments_count, bookmarks},
   priority,
   variant = 'default',
 }: Props) {
@@ -49,7 +49,7 @@ export default function CardDescription({
         </div>
       </div>
 
-      <p className="text-boldBlue text-sm">{author_id}</p>
+      <p className="text-boldBlue text-sm">{author_nickname}</p>
 
       <div className="flex mb-5 gap-7 text-sm font-normal">
         <div className="flex gap-1 items-center">

--- a/src/entities/reviews/ui/ReviewArticle.tsx
+++ b/src/entities/reviews/ui/ReviewArticle.tsx
@@ -9,7 +9,7 @@ type Props = {
 };
 
 export default function ReviewArticle({
-  searchReview: {author_id, board_id, bookmarks, category, comments_count, preview, created_at, image_url, title},
+  searchReview: {author_nickname, board_id, bookmarks, category, comments_count, preview, created_at, image_url, title},
   priority,
 }: Props) {
   return (
@@ -24,7 +24,7 @@ export default function ReviewArticle({
             <p className="text-sm text-gray-500 mb-1">{created_at}</p>
             <div className="flex gap-3 text-sm text-gray-500">
               <p>{CATEGORY_MAP[category]}</p>
-              <p>{author_id}</p>
+              <p>{author_nickname}</p>
             </div>
           </article>
           <article className="px-4 md:px-0 text-sm line-clamp-2 md:line-clamp-3 mb-4 md:mb-7 md:flex-1 md:max-w-[400px] lg:max-w-[550px]">

--- a/src/features/reviews/my/ui/MyBookmarkedReviews.tsx
+++ b/src/features/reviews/my/ui/MyBookmarkedReviews.tsx
@@ -2,7 +2,7 @@ import Empty from './Empty';
 import MyReviewsGrid from './MyReviewsGrid';
 import Pagination from '@/widgets/pagination';
 import {useMyBookmarkedReviews} from '@/entities/reviews';
-import {useUserEmail} from '@/entities/auth';
+import {useUserNickname} from '@/entities/auth';
 
 type Props = {
   currentPage: number;
@@ -10,7 +10,7 @@ type Props = {
 
 export default function MyBookmarkedReviews({currentPage}: Props) {
   const {results, total_pages} = useMyBookmarkedReviews(currentPage);
-  const userEmail = useUserEmail();
+  const userNickname = useUserNickname();
 
   if (results.length === 0) {
     return <Empty title="아직 저장한 후기가 없어요." linkText="후기 보러가기" linkHref="/search" />;
@@ -18,7 +18,7 @@ export default function MyBookmarkedReviews({currentPage}: Props) {
 
   return (
     <section>
-      <MyReviewsGrid reviews={results} context="myBookmarks" userEmail={userEmail} />
+      <MyReviewsGrid reviews={results} context="myBookmarks" userNickname={userNickname} />
       <Pagination
         currentPage={currentPage}
         totalPages={total_pages}

--- a/src/features/reviews/my/ui/MyReviewsGrid.tsx
+++ b/src/features/reviews/my/ui/MyReviewsGrid.tsx
@@ -9,7 +9,7 @@ type Props =
   | {
       reviews: ReviewCard[];
       context: 'myBookmarks';
-      userEmail: string | null;
+      userNickname: string | null;
     };
 
 export default function MyReviewsGrid(props: Props) {
@@ -18,7 +18,7 @@ export default function MyReviewsGrid(props: Props) {
   return (
     <ul className="w-full grid content-center justify-items-center grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-y-14 md:gap-y-10">
       {reviews.map((card, index) => {
-        const isAuthor = context === 'my' || card.author_email === props.userEmail;
+        const isAuthor = context === 'my' || card.author_nickname === props.userNickname;
         const shouldPrioritize = index < 3;
 
         return (


### PR DESCRIPTION
## 📝 요약(Summary)

- features, entities 레이어의 reviews 도메인에서 닉네임을 사용하도록 수정.

### `src/entities/reviews/ui/CardDescription.tsx`
### `src/entities/reviews/ui/ReviewArticle.tsx`
- `author_id`를 제거하고 `author_nickname`을 사용하도록 변경.

### `src/features/reviews/my/ui/MyBookmarkedReviews.tsx`
- `MyReviewsGrid` 컴포넌트로 `userNickname`을 전달하도록 변경.

### `src/features/reviews/my/ui/MyReviewsGrid.tsx`
- 인자로 `userNickname`을 받도록 변경.
- 작성자 판단에 `author_nickname`과 `userNickname`을 비교하도록 변경.

## 🛠️ PR 유형

- [X] 코드 리팩토링
