### PR TITLE
Fix(views) - views 레이어에서 닉네임을 사용하도록 변경

### DIFF
--- a/src/shared/lib/utils/getSessionUserEmail.ts
+++ b/src/shared/lib/utils/getSessionUserEmail.ts
@@ -1,8 +1,0 @@
-import {cookies} from 'next/headers';
-
-export default async function getSessionUserEmail() {
-  const cookieStore = await cookies();
-  const sessionUserEmail = cookieStore.get('userEmail');
-
-  return sessionUserEmail ? sessionUserEmail.value : null;
-}

--- a/src/shared/lib/utils/getSessionUserNickname.ts
+++ b/src/shared/lib/utils/getSessionUserNickname.ts
@@ -1,0 +1,8 @@
+import {cookies} from 'next/headers';
+
+export default async function getSessionUserNickname() {
+  const cookieStore = await cookies();
+  const sessionUserNickname = cookieStore.get('userNickname');
+
+  return sessionUserNickname ? sessionUserNickname.value : null;
+}

--- a/src/views/mypage/ui/UserInfo.tsx
+++ b/src/views/mypage/ui/UserInfo.tsx
@@ -1,12 +1,11 @@
 'use client';
 
 import Image from 'next/image';
-import {useUserEmail, useUserId} from '@/entities/auth';
+import {useUserNickname} from '@/entities/auth';
 import {Skeleton} from '@/shared/shadcnComponent/ui/skeleton';
 
 export default function UserInfo() {
-  const userId = useUserId();
-  const userEmail = useUserEmail();
+  const userNickname = useUserNickname();
 
   return (
     <section className="flex flex-col items-center mt-10 md:mt-8 lg:mt-10">
@@ -14,7 +13,7 @@ export default function UserInfo() {
         <Image
           // TODO: 실제 사용자 프로필 이미지로 변경
           src="https://picsum.photos/seed/ee2/200/200"
-          alt={`${userId} 프로필 사진`}
+          alt={`${userNickname} 프로필 사진`}
           width={160}
           height={160}
           className="w-full h-full object-cover"
@@ -22,15 +21,10 @@ export default function UserInfo() {
         />
       </div>
       <div className="flex flex-col items-center mt-3">
-        {userId ? (
-          <p className="text-xl lg:text-2xl font-bold">{userId}</p>
+        {userNickname ? (
+          <p className="text-xl lg:text-2xl font-bold">{userNickname}</p>
         ) : (
           <Skeleton className="h-5 md:h-6 lg:h-7 w-32 md:w-36 lg:w-40 mb-1 mt-2 md:mt-0" />
-        )}
-        {userEmail ? (
-          <p className="text-sm md:text-base font-semibold text-boldBlue">{userEmail}</p>
-        ) : (
-          <Skeleton className="h-4 md:h-5 lg:h-6 w-40 md:w-48 lg:w-52" />
         )}
       </div>
     </section>

--- a/src/views/review/detail/ui/ReviewDetailPage.tsx
+++ b/src/views/review/detail/ui/ReviewDetailPage.tsx
@@ -3,7 +3,7 @@ import ReviewDetailInteractive from './ReviewDetailInteractive';
 import {Viewer} from '@/features/review/viewer';
 import {DeleteButton} from '@/entities/reviews';
 import {getReviewDetail} from '@/entities/review';
-import getSessionUserEmail from '@/shared/lib/utils/getSessionUserEmail';
+import getSessionUserNickname from '@/shared/lib/utils/getSessionUserNickname';
 
 type Props = {
   params: Promise<{reviewId: string}>;
@@ -13,10 +13,10 @@ export default async function ReviewDetailPage({params}: Props) {
   const {reviewId} = await params;
   const parsedReviewId = Number(reviewId);
 
-  const {author_id, author_email, content, category, created_at, title} = await getReviewDetail(parsedReviewId);
+  const {author_nickname, content, category, created_at, title} = await getReviewDetail(parsedReviewId);
 
-  const sessionUserEmail = await getSessionUserEmail();
-  const isAuthor = sessionUserEmail === author_email;
+  const sessionUserNickname = await getSessionUserNickname();
+  const isAuthor = sessionUserNickname === author_nickname;
 
   return (
     <section className="flex flex-col w-full max-w-5xl mx-auto items-center relative pt-1 md:pt-3">
@@ -30,8 +30,7 @@ export default async function ReviewDetailPage({params}: Props) {
       )}
       <Viewer
         title={title}
-        author_id={author_id}
-        author_email={author_email}
+        author_nickname={author_nickname}
         content={content}
         category={category}
         created_at={created_at}

--- a/src/views/review/edit/ui/EditReview.tsx
+++ b/src/views/review/edit/ui/EditReview.tsx
@@ -3,13 +3,13 @@ import {getReviewDetail} from '@/entities/review';
 
 type Props = {
   reviewId: number;
-  sessionUserEmail: string;
+  sessionUserNickname: string;
 };
 
-export default async function EditReview({reviewId, sessionUserEmail}: Props) {
+export default async function EditReview({reviewId, sessionUserNickname}: Props) {
   const data = await getReviewDetail(reviewId);
 
-  if (data.author_email !== sessionUserEmail) {
+  if (data.author_nickname !== sessionUserNickname) {
     throw new Error('작성자만 리뷰를 수정할 수 있습니다.');
   }
 

--- a/src/views/review/edit/ui/EditReviewPage.tsx
+++ b/src/views/review/edit/ui/EditReviewPage.tsx
@@ -1,7 +1,7 @@
 import {Suspense} from 'react';
 import EditReview from './EditReview';
 import {LoadingSpinner} from '@/shared/ui/components';
-import getSessionUserEmail from '@/shared/lib/utils/getSessionUserEmail';
+import getSessionUserNickname from '@/shared/lib/utils/getSessionUserNickname';
 
 type Props = {
   params: Promise<{reviewId: string}>;
@@ -11,16 +11,16 @@ export default async function ReviewEditPage({params}: Props) {
   const {reviewId} = await params;
   const parsedReviewId = Number(reviewId);
 
-  const sessionUserEmail = await getSessionUserEmail();
+  const sessionUserNickname = await getSessionUserNickname();
 
-  if (!sessionUserEmail) {
+  if (!sessionUserNickname) {
     throw new Error('로그인 세션이 만료되었습니다. 다시 로그인해주세요.');
   }
 
   return (
     <section className="fixed inset-0 z-20 bg-gray-50">
       <Suspense fallback={<LoadingSpinner text="리뷰 정보를 불러오고 있어요." />}>
-        <EditReview reviewId={parsedReviewId} sessionUserEmail={sessionUserEmail} />
+        <EditReview reviewId={parsedReviewId} sessionUserNickname={sessionUserNickname} />
       </Suspense>
     </section>
   );


### PR DESCRIPTION
## 📝 요약(Summary)

- views 레이어에서 닉네임을 사용하도록 변경

### `src/shared/lib/utils/getSessionUserNickname.ts`
- 기존의 `getSessionUserEmail`을 변경.
- `userNickname` 쿠키의 `value`를 반환하는 함수로 변경.

### `src/views/mypage/ui/UserInfo.tsx`
- `userId`, `userEmail` 대신 `userNickname` 값을 표시하도록 변경.

### `src/views/review/detail/ui/ReviewDetailPage.tsx`
- `getReviewDetail`의 반환 값에서 `author_id`, `author_email`을 제거, `author_nickname` 추가.
- 작성자 판단에 `sessionUserNickname`과 `author_nickname`을 비교하도록 변경.
- `Viewer` 컴포넌트로 `author_nickname`을 전달하도록 변경.

### `src/views/review/edit/ui/EditReview.tsx`
- 인자로 `sessionUserNickname`을 받도록 변경.
- 작성자가 아닌 경우를 판단할 때 `data` 객체의 `author_nickname`과 `sessionUserNickname`을 비교하도록 변경.

### `src/views/review/edit/ui/EditReviewPage.tsx`
- `sessionUserEmail` 대신 `sessionUserNickname`을 가져오도록 변경.
- `EditReview` 컴포넌트로 `sessionUserNickname`을 전달하도록 변경.

## 🛠️ PR 유형

- [X] 코드 리팩토링
