### PR TITLE
Fix(메타데이터) - 엔트리파일에 metadata, generateMetadata 연결, 검색, 상세보기, 문의하기, 사용자별 게시글 페이지 og title, description 추가

### DIFF
--- a/app/contact/page.ts
+++ b/app/contact/page.ts
@@ -1,1 +1,1 @@
-export {ContactPage as default} from '@/views/contact';
+export {ContactPage as default, metadata} from '@/views/contact';

--- a/app/mypage/page.ts
+++ b/app/mypage/page.ts
@@ -1,1 +1,1 @@
-export {MyPage as default} from '@/views/mypage';
+export {MyPage as default, metadata} from '@/views/mypage';

--- a/app/notifications/page.ts
+++ b/app/notifications/page.ts
@@ -1,1 +1,1 @@
-export {NotificationsPage as default} from '@/views/notifications';
+export {NotificationsPage as default, metadata} from '@/views/notifications';

--- a/app/oauth2/redirect/page.ts
+++ b/app/oauth2/redirect/page.ts
@@ -1,3 +1,3 @@
 export const dynamic = 'force-dynamic';
 
-export {OAuth2RedirectPage as default} from '@/views/oauth2';
+export {OAuth2RedirectPage as default, metadata} from '@/views/oauth2';

--- a/app/reviews/[reviewId]/edit/page.ts
+++ b/app/reviews/[reviewId]/edit/page.ts
@@ -1,1 +1,1 @@
-export {EditReviewPage as default} from '@/views/review/edit';
+export {EditReviewPage as default, generateMetadata} from '@/views/review/edit';

--- a/app/reviews/[reviewId]/page.ts
+++ b/app/reviews/[reviewId]/page.ts
@@ -1,1 +1,1 @@
-export {ReviewDetailPage as default} from '@/views/review/detail';
+export {ReviewDetailPage as default, generateMetadata} from '@/views/review/detail';

--- a/app/reviews/new/page.ts
+++ b/app/reviews/new/page.ts
@@ -1,1 +1,1 @@
-export {NewReviewPage as default} from '@/views/review/new';
+export {NewReviewPage as default, metadata} from '@/views/review/new';

--- a/app/search/[keyword]/page.ts
+++ b/app/search/[keyword]/page.ts
@@ -1,3 +1,3 @@
 export const dynamic = 'force-dynamic';
 
-export {KeywordSearchPage as default} from '@/views/search';
+export {KeywordSearchPage as default, generateMetadata} from '@/views/search';

--- a/app/search/page.ts
+++ b/app/search/page.ts
@@ -1,3 +1,3 @@
 export const dynamic = 'force-dynamic';
 
-export {CategorySearchPage as default} from '@/views/search';
+export {CategorySearchPage as default, metadata} from '@/views/search';

--- a/app/users/[userNickname]/page.ts
+++ b/app/users/[userNickname]/page.ts
@@ -1,1 +1,1 @@
-export {PostsByUserPage as default} from '@/views/users/reviews';
+export {PostsByUserPage as default, generateMetadata} from '@/views/users/reviews';

--- a/src/app/layouts/index.tsx
+++ b/src/app/layouts/index.tsx
@@ -9,7 +9,7 @@ import {Toaster} from 'sonner';
 export const metadata: Metadata = {
   title: {
     default: '모두의 후기',
-    template: '모두의 후기 | %s',
+    template: '%s | 모두의 후기',
   },
   description: '당신이 찾던 그 후기를 확인해보세요.',
   icons: {

--- a/src/views/contact/index.ts
+++ b/src/views/contact/index.ts
@@ -1,1 +1,1 @@
-export {default as ContactPage} from './ui/ContactPage';
+export {default as ContactPage, metadata} from './ui/ContactPage';

--- a/src/views/contact/ui/ContactPage.tsx
+++ b/src/views/contact/ui/ContactPage.tsx
@@ -4,6 +4,10 @@ import {Metadata} from 'next';
 export const metadata: Metadata = {
   title: '문의하기',
   description: '문의사항을 작성해주세요.',
+  openGraph: {
+    title: '문의하기',
+    description: '문의사항을 작성해주세요.',
+  },
 };
 
 export default function ContactPage() {

--- a/src/views/mypage/index.ts
+++ b/src/views/mypage/index.ts
@@ -1,1 +1,1 @@
-export {default as MyPage} from './ui/MyPage';
+export {default as MyPage, metadata} from './ui/MyPage';

--- a/src/views/notifications/index.ts
+++ b/src/views/notifications/index.ts
@@ -1,1 +1,1 @@
-export {default as NotificationsPage} from './ui/NotificationsPage';
+export {default as NotificationsPage, metadata} from './ui/NotificationsPage';

--- a/src/views/oauth2/index.ts
+++ b/src/views/oauth2/index.ts
@@ -1,2 +1,2 @@
 export {default as OAuth2ErrorFallback} from './ui/OAuth2ErrorFallback';
-export {default as OAuth2RedirectPage} from './ui/OAuth2RedirectPage';
+export {default as OAuth2RedirectPage, metadata} from './ui/OAuth2RedirectPage';

--- a/src/views/review/detail/index.ts
+++ b/src/views/review/detail/index.ts
@@ -1,1 +1,1 @@
-export {default as ReviewDetailPage} from './ui/ReviewDetailPage';
+export {default as ReviewDetailPage, generateMetadata} from './ui/ReviewDetailPage';

--- a/src/views/review/detail/ui/ReviewDetailPage.tsx
+++ b/src/views/review/detail/ui/ReviewDetailPage.tsx
@@ -20,6 +20,10 @@ export async function generateMetadata({params}: Props) {
     return {
       title: post.title,
       description: `${post.title}에 대한 자세한 후기를 확인해보세요.`,
+      openGraph: {
+        title: post.title,
+        description: `${post.title}에 대한 자세한 후기를 확인해보세요.`,
+      },
     };
   }
 }

--- a/src/views/review/edit/index.ts
+++ b/src/views/review/edit/index.ts
@@ -1,1 +1,1 @@
-export {default as EditReviewPage} from './ui/EditReviewPage';
+export {default as EditReviewPage, generateMetadata} from './ui/EditReviewPage';

--- a/src/views/review/new/index.ts
+++ b/src/views/review/new/index.ts
@@ -1,1 +1,1 @@
-export {default as NewReviewPage} from './ui/NewReviewPage';
+export {default as NewReviewPage, metadata} from './ui/NewReviewPage';

--- a/src/views/search/index.ts
+++ b/src/views/search/index.ts
@@ -1,2 +1,2 @@
-export {default as CategorySearchPage} from './ui/CategorySearchPage';
-export {default as KeywordSearchPage} from './ui/KeywordSearchPage';
+export {default as CategorySearchPage, metadata} from './ui/CategorySearchPage';
+export {default as KeywordSearchPage, generateMetadata} from './ui/KeywordSearchPage';

--- a/src/views/search/ui/CategorySearchPage.tsx
+++ b/src/views/search/ui/CategorySearchPage.tsx
@@ -7,6 +7,10 @@ import {CategoryReviews} from '@/features/reviews/category';
 export const metadata: Metadata = {
   title: '후기글 모음',
   description: '카테고리별로 후기글을 모아보세요.',
+  openGraph: {
+    title: '후기글 모음',
+    description: '카테고리별로 후기글을 모아보세요.',
+  },
 };
 
 export default function CategorySearchPage() {

--- a/src/views/search/ui/KeywordSearchPage.tsx
+++ b/src/views/search/ui/KeywordSearchPage.tsx
@@ -15,6 +15,10 @@ export async function generateMetadata({params}: Props) {
   return {
     title: `${decodedQuery} 검색 결과`,
     description: `${decodedQuery}에 관련된 후기글을 모아보세요.`,
+    openGraph: {
+      title: `${decodedQuery} 검색 결과`,
+      description: `${decodedQuery}에 관련된 후기글을 모아보세요.`,
+    },
   };
 }
 

--- a/src/views/users/reviews/index.ts
+++ b/src/views/users/reviews/index.ts
@@ -1,1 +1,1 @@
-export {default as PostsByUserPage} from './ui/PostsByUserPage';
+export {default as PostsByUserPage, generateMetadata} from './ui/PostsByUserPage';

--- a/src/views/users/reviews/ui/PostsByUserPage.tsx
+++ b/src/views/users/reviews/ui/PostsByUserPage.tsx
@@ -14,6 +14,10 @@ export async function generateMetadata({params}: Props) {
   return {
     title: `${decodedUserNickname}님의 후기글 모음`,
     description: `${decodedUserNickname}님의 후기글을 모아보세요.`,
+    openGraph: {
+      title: `${decodedUserNickname}님의 후기글 모음`,
+      description: `${decodedUserNickname}님의 후기글을 모아보세요.`,
+    },
   };
 }
 


### PR DESCRIPTION
## 📝 요약(Summary)

- #72 
- 엔트리 파일에 metadata 객체와 generateMetadata 함수 연결.
- 검색하기, 사용자별 게시글 모아보기, 게시글 상세보기, 문의하기 페이지의 og title, description 추가.

## 🛠️ PR 유형

- [X] 새로운 기능 추가